### PR TITLE
bug-fixes-address-and-my-markets

### DIFF
--- a/src/modules/account/components/account-rep-faucet/account-rep-faucet.jsx
+++ b/src/modules/account/components/account-rep-faucet/account-rep-faucet.jsx
@@ -21,7 +21,6 @@ const AccountRepFaucet = p => (
 
 
 AccountRepFaucet.propTypes = {
-  address: PropTypes.string.isRequired,
   repFaucet: PropTypes.func.isRequired,
 }
 

--- a/src/modules/account/containers/account-deposit.js
+++ b/src/modules/account/containers/account-deposit.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import AccountDeposit from 'modules/account/components/account-deposit/account-deposit'
 
 const mapStateToProps = state => ({
-  address: state.loginAccount.address,
+  address: state.loginAccount.displayAddress,
 })
 
 const AccountDepositContainer = connect(mapStateToProps)(AccountDeposit)

--- a/src/modules/account/containers/account-rep-faucet.js
+++ b/src/modules/account/containers/account-rep-faucet.js
@@ -4,7 +4,6 @@ import getRep from 'modules/account/actions/get-rep'
 import AccountRepFaucet from 'modules/account/components/account-rep-faucet/account-rep-faucet'
 
 const mapStateToProps = state => ({
-  address: state.loginAccount.address,
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/modules/auth/actions/update-is-logged-and-load-account-data.js
+++ b/src/modules/auth/actions/update-is-logged-and-load-account-data.js
@@ -7,9 +7,11 @@ import { clearLoginAccount } from 'modules/auth/actions/update-login-account'
 export const updateIsLoggedAndLoadAccountData = (unlockedAddress, accountType) => (dispatch) => {
   augur.rpc.clear() // clear ethrpc transaction history, registered callbacks, and notifications
   dispatch(clearLoginAccount()) // clear the loginAccount data in local state
-  const address = toChecksumAddress(unlockedAddress)
+  const displayAddress = toChecksumAddress(unlockedAddress)
+  const address = unlockedAddress
   const loginAccount = {
     address,
+    displayAddress,
     meta: { accountType, address, signer: null },
   }
   dispatch(updateIsLogged(true))

--- a/src/modules/portfolio/components/markets/markets.jsx
+++ b/src/modules/portfolio/components/markets/markets.jsx
@@ -72,7 +72,7 @@ class MyMarkets extends Component {
   componentWillReceiveProps(nextProps) {
     const { myMarkets } = this.props
     // update the filtered markets if the myMarkets prop changes
-    if (myMarkets !== nextProps.myMarkets) {
+    if (myMarkets.length !== nextProps.myMarkets.length) {
       const openMarkets = []
       const reportingMarkets = []
       const finalMarkets = []

--- a/src/modules/portfolio/containers/markets.js
+++ b/src/modules/portfolio/containers/markets.js
@@ -29,7 +29,7 @@ const mapDispatchToProps = dispatch => ({
   loadMarkets: () => dispatch(loadUserMarkets((err, marketIds) => {
     if (err) return logError(err)
     // if we have marketIds back, let's load the info so that we can properly display myMarkets.
-    dispatch(loadMarketsInfo(marketIds))
+    dispatch(loadMarketsInfoIfNotLoaded(marketIds))
     dispatch(loadUnclaimedFees(marketIds))
   })),
   collectMarketCreatorFees: (marketId, callback) => dispatch(collectMarketCreatorFees(marketId, callback)),

--- a/test/auth/actions/update-is-logged-and-load-account-data.js
+++ b/test/auth/actions/update-is-logged-and-load-account-data.js
@@ -32,7 +32,7 @@ describe(`modules/auth/actions/update-is-logged-and-load-account-data.js`, () =>
       { type: 'AUGURJS_RPC_CLEAR' },
       { type: 'CLEAR_LOGIN_ACCOUNT' },
       { type: 'UPDATE_IS_LOGGED', data: { isLogged: true } },
-      { type: 'LOAD_ACCOUNT_DATA', account: { address: '0xB0B', meta: { accountType: 'unlockedEthereumNode', address: '0xB0B', signer: null } } },
+      { type: 'LOAD_ACCOUNT_DATA', account: { address: '0xb0b', displayAddress: '0xB0B', meta: { accountType: 'unlockedEthereumNode', address: '0xb0b', signer: null } } },
     ]),
   })
   test({
@@ -45,7 +45,7 @@ describe(`modules/auth/actions/update-is-logged-and-load-account-data.js`, () =>
       { type: 'AUGURJS_RPC_CLEAR' },
       { type: 'CLEAR_LOGIN_ACCOUNT' },
       { type: 'UPDATE_IS_LOGGED', data: { isLogged: true } },
-      { type: 'LOAD_ACCOUNT_DATA', account: { address: '0xB0B', meta: { accountType: 'metaMask', address: '0xB0B', signer: null } } },
+      { type: 'LOAD_ACCOUNT_DATA', account: { address: '0xb0b', displayAddress: '0xB0B', meta: { accountType: 'metaMask', address: '0xb0b', signer: null } } },
     ]),
   })
 })


### PR DESCRIPTION
fixed an issue with my-markets being cleared away when it shouldn't have been. broke out the checksum address into a new value called display address to clear up bugs caused by using it when augur-node returns lowercase address data

No clubhouse story because i just found these bugs while writing up the walkthrough for trading.

my markets would briefly show all the markets then flash them away and make it look like we didn't have any markets.

the other bug was introduced when we changed to use checksum addresses. There are a couple occasions where we do something like `loginAccount.address === order.owner` the problem here is Augur Node is catching these checksum addresses but the data returned is in lowercase addresses. So the solution was to revert `address` back to lowercase and add a new field called `displayAddress` to the loginAccount object that we can use to display a checksum address. If we would prefer to use checksum addresses everywhere I believe it might be better to save that for peccary.

## Submitter checklist
- [ ] Test covering functionality added/fixed in
- Check the linked story includes the following:
  - [ ] Steps to reproduce
  - [ ] Screenshot (If applicable)

## Reviewer Checklist
- [ ] Test/lint pass 
