### PR TITLE
Transactions fail with uPort

### DIFF
--- a/src/modules/auth/actions/login-with-uport.js
+++ b/src/modules/auth/actions/login-with-uport.js
@@ -1,17 +1,19 @@
+import { toChecksumAddress } from 'ethereumjs-util'
+import { decode } from 'mnid'
 import { augur } from 'services/augurjs'
 import { updateIsLogged } from 'modules/auth/actions/update-is-logged'
 import { loadAccountData } from 'modules/auth/actions/load-account-data'
 import { uPortSigner } from 'modules/auth/helpers/uport-signer'
-import { toChecksumAddress } from 'ethereumjs-util'
 
-export const loginWithUport = account => (dispatch) => {
+export const loginWithUport = (credentials, uPort) => (dispatch) => {
+  const account = decode(credentials.address)
   dispatch(updateIsLogged(true))
   dispatch(loadAccountData({
     ...account,
     displayAddress: toChecksumAddress(account.address),
     meta: {
       address: account.address,
-      signer: transaction => dispatch(uPortSigner(transaction)),
+      signer: transaction => dispatch(uPortSigner(uPort, transaction)),
       accountType: augur.rpc.constants.ACCOUNT_TYPES.U_PORT,
     },
   }))

--- a/src/modules/auth/components/uport-connect/uport-connect.jsx
+++ b/src/modules/auth/components/uport-connect/uport-connect.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import QRCode from 'qrcode.react'
-import { decode } from 'mnid'
 
 import { AppleAppStore, GooglePlayStore } from 'modules/common/components/icons'
 
@@ -15,12 +14,12 @@ export default class UportConnect extends Component {
   static propTypes = {
     isMobile: PropTypes.bool.isRequired,
     isMobileSmall: PropTypes.bool.isRequired,
+    networkId: PropTypes.string.isRequired,
     login: PropTypes.func.isRequired,
   }
 
   constructor() {
     super()
-    this.uPort = connectToUport()
     this.state = { uri: '', qrSize: 0 }
     this.uPortURIHandler = this.uPortURIHandler.bind(this)
     this.setQRSize = this.setQRSize.bind(this)
@@ -29,8 +28,9 @@ export default class UportConnect extends Component {
 
   componentWillMount() {
     const { login } = this.props
-    this.uPort.requestCredentials({ notifcations: true }, this.uPortURIHandler).then((account) => {
-      login(decode(account.address))
+    const uPort = connectToUport(this.props.networkId)
+    uPort.requestCredentials({ notifcations: true, accountType: 'keypair' }, this.uPortURIHandler).then((credentials) => {
+      login(credentials, uPort)
     })
   }
 

--- a/src/modules/auth/components/uport-create/uport-create.jsx
+++ b/src/modules/auth/components/uport-create/uport-create.jsx
@@ -7,20 +7,18 @@ import { AppleAppStore, GooglePlayStore } from 'modules/common/components/icons'
 import debounce from 'utils/debounce'
 import getValue from 'utils/get-value'
 
-import { decode } from 'mnid'
-
 import { connectToUport } from 'modules/auth/helpers/connect-to-uport'
 import Styles from 'modules/auth/components/uport-create/uport-create.styles'
 
 export default class UportCreate extends Component {
   static propTypes = {
     isMobile: PropTypes.bool.isRequired,
+    networkId: PropTypes.string.isRequired,
     login: PropTypes.func.isRequired,
   }
 
   constructor() {
     super()
-    this.uPort = connectToUport()
     this.state = { uri: '', qrSize: 0 }
     this.uPortURIHandler = this.uPortURIHandler.bind(this)
     this.setQRSize = this.setQRSize.bind(this)
@@ -29,8 +27,9 @@ export default class UportCreate extends Component {
 
   componentWillMount() {
     const { login } = this.props
-    this.uPort.requestCredentials({ notifcations: true }, this.uPortURIHandler).then((account) => {
-      login(decode(account.address))
+    const uPort = connectToUport(this.props.networkId)
+    uPort.requestCredentials({ notifcations: true, accountType: 'keypair' }, this.uPortURIHandler).then((credentials) => {
+      login(credentials, uPort)
     })
   }
 

--- a/src/modules/auth/containers/uport-connect.js
+++ b/src/modules/auth/containers/uport-connect.js
@@ -1,14 +1,16 @@
 import { connect } from 'react-redux'
+import { augur } from 'services/augurjs'
 import UportConnect from 'modules/auth/components/uport-connect/uport-connect'
 import { loginWithUport } from 'modules/auth/actions/login-with-uport'
 
 const mapStateToProps = state => ({
   isMobile: state.isMobile,
   isMobileSmall: state.isMobileSmall,
+  networkId: augur.rpc.getNetworkID(),
 })
 
 const mapDispatchToProps = dispatch => ({
-  login: account => dispatch(loginWithUport(account)),
+  login: (credentials, uPort) => dispatch(loginWithUport(credentials, uPort)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(UportConnect)

--- a/src/modules/auth/containers/uport-create.js
+++ b/src/modules/auth/containers/uport-create.js
@@ -1,13 +1,15 @@
 import { connect } from 'react-redux'
+import { augur } from 'services/augurjs'
 import UportCreate from 'modules/auth/components/uport-create/uport-create'
 import { loginWithUport } from 'modules/auth/actions/login-with-uport'
 
 const mapStateToProps = state => ({
   isMobile: state.isMobile,
+  networkId: augur.rpc.getNetworkID(),
 })
 
 const mapDispatchToProps = dispatch => ({
-  login: account => dispatch(loginWithUport(account)),
+  login: (credentials, uPort) => dispatch(loginWithUport(credentials, uPort)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(UportCreate)

--- a/src/modules/auth/helpers/connect-to-uport.js
+++ b/src/modules/auth/helpers/connect-to-uport.js
@@ -1,3 +1,4 @@
+import memoize from 'memoizee'
 import { Connect } from 'uport-connect'
 import { augur } from 'services/augurjs'
 
@@ -8,8 +9,7 @@ const NETWORKS = {
   42: 'kovan',
 }
 
-export const connectToUport = () => new Connect('AUGUR -- DEV', {
+export const connectToUport = memoize(() => new Connect('AUGUR -- DEV', {
   clientId: '2ofGiHuZhhpDMAQeDxjoDhEsUQd1MayECgd',
-  accountType: 'keypair',
   network: NETWORKS[augur.rpc.getNetworkID()],
-})
+}), { max: 1 })

--- a/src/modules/auth/helpers/uport-signer.js
+++ b/src/modules/auth/helpers/uport-signer.js
@@ -1,10 +1,9 @@
-import { connectToUport } from 'modules/auth/helpers/connect-to-uport'
 import { updateModal } from 'modules/modal/actions/update-modal'
 import { closeModal } from 'modules/modal/actions/close-modal'
 import { MODAL_UPORT } from 'modules/modal/constants/modal-types'
 
-export const uPortSigner = transaction => (dispatch) => {
-  const uPortSigner = connectToUport().sendTransaction(transaction, uri => dispatch(updateModal({ type: MODAL_UPORT, uri })))
+export const uPortSigner = (uPort, transaction) => (dispatch, getState) => {
+  const uPortSigner = uPort.sendTransaction(transaction, uri => dispatch(updateModal({ type: MODAL_UPORT, uri })))
   uPortSigner
     .then(() => dispatch(closeModal()))
     .catch(err => dispatch(updateModal({ type: MODAL_UPORT, error: `Failed to Sign with "${err}"`, canClose: true })))

--- a/test/auth/helpers/uport-signer-test.js
+++ b/test/auth/helpers/uport-signer-test.js
@@ -11,10 +11,12 @@ sinonStubPromise(sinon)
 describe('modules/auth/helpers/uport-signer.js', () => {
   const store = configureMockStore([thunk])({})
   let stubbedSendTransaction
+  let stubbedUport
   __RewireAPI__.__Rewire__('updateModal', sinon.stub().returnsArg(0))
   __RewireAPI__.__Rewire__('closeModal', sinon.stub().returns({ type: 'close-stub' }))
   beforeEach(() => {
     stubbedSendTransaction = sinon.stub(Connect.prototype, 'sendTransaction').returnsPromise()
+    stubbedUport = { sendTransaction: stubbedSendTransaction }
   })
   after(() => {
     __RewireAPI__.__ResetDependency__('updateModal')
@@ -26,17 +28,17 @@ describe('modules/auth/helpers/uport-signer.js', () => {
   })
   it('should call the expected actions from the `sendTransaction` callback', () => {
     stubbedSendTransaction.yields('test-uri')
-    store.dispatch(uPortSigner({}))
+    store.dispatch(uPortSigner(stubbedUport, {}))
     assert.deepEqual(store.getActions(), [{ type: MODAL_UPORT, uri: 'test-uri' }])
   })
   it(`should dispatch the expected actions on 'resolve'`, () => {
     stubbedSendTransaction.resolves()
-    store.dispatch(uPortSigner({}))
+    store.dispatch(uPortSigner(stubbedUport, {}))
     assert.deepEqual(store.getActions(), [{ type: 'close-stub' }])
   })
   it(`should dispatch the expected actions on 'resolve'`, () => {
     stubbedSendTransaction.rejects('test-err')
-    store.dispatch(uPortSigner({}))
+    store.dispatch(uPortSigner(stubbedUport, {}))
     assert.deepEqual(store.getActions(), [{ type: MODAL_UPORT, error: `Failed to Sign with "test-err"`, canClose: true }])
   })
 })


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/10009

As far as I can tell, basic transactions are working properly (as is logging in, etc.) at this point.  The remaining problem is that uPort's transactions are still using the `relayMetaTx` function, which seems to mess up the `msg.sender` address for the purposes of creating orders.