### PR TITLE
johndanz/ch14213/market-liquidity-order-price-grouping

### DIFF
--- a/src/modules/create-market/reducers/new-market.js
+++ b/src/modules/create-market/reducers/new-market.js
@@ -68,15 +68,27 @@ export default function (newMarket = DEFAULT_STATE(), action) {
   switch (action.type) {
     case ADD_ORDER_TO_NEW_MARKET: {
       const existingOrders = newMarket.orderBook[action.data.outcome] || []
+      const orderToAdd = action.data
+      let orderAdded = false
+      const updatedOrders = existingOrders.reduce((Orders, order) => {
+        const orderInfo = Object.assign({}, order)
+        if (order.price.eq(orderToAdd.price) && order.type === orderToAdd.type) {
+          orderInfo.quantity = order.quantity.plus(orderToAdd.quantity)
+          orderAdded = true
+        }
+        Orders.push(orderInfo)
+        return Orders
+      }, [])
+
+      if (!orderAdded) {
+        updatedOrders.push({ type: action.data.type, price: action.data.price, quantity: action.data.quantity })
+      }
 
       return {
         ...newMarket,
         orderBook: {
           ...newMarket.orderBook,
-          [action.data.outcome]: [
-            ...existingOrders,
-            { type: action.data.type, price: action.data.price, quantity: action.data.quantity },
-          ],
+          [action.data.outcome]: updatedOrders,
         },
       }
     }

--- a/test/create-market/reducers/new-market-test.js
+++ b/test/create-market/reducers/new-market-test.js
@@ -187,6 +187,132 @@ describe('modules/create-market/reducers/new-market.js', () => {
   })
 
   test({
+    describe: 'should add order to an existing outcome that has an order at that price point',
+    assertions: () => {
+      const newMarketState = {
+        test: 'test',
+        orderBook: {
+          Outcome1: [
+            {
+              type: 'bid',
+              price: createBigNumber(0.3),
+              quantity: createBigNumber(1),
+            },
+            {
+              type: 'ask',
+              price: createBigNumber(0.9),
+              quantity: createBigNumber(1),
+            },
+          ],
+        },
+      }
+
+      const actual = newMarket(newMarketState, {
+        type: ADD_ORDER_TO_NEW_MARKET,
+        data: {
+          outcome: 'Outcome1',
+          type: 'bid',
+          price: createBigNumber(0.3),
+          quantity: createBigNumber(1),
+        },
+      })
+
+      const expected = {
+        test: 'test',
+        orderBook: {
+          Outcome1: [
+            {
+              type: 'bid',
+              price: createBigNumber(0.3),
+              quantity: createBigNumber(2),
+            },
+            {
+              type: 'ask',
+              price: createBigNumber(0.9),
+              quantity: createBigNumber(1),
+            },
+          ],
+        },
+      }
+
+      assert.deepEqual(actual, expected, `Didn't return the expected orderBook object`)
+    },
+  })
+
+  test({
+    describe: 'should add multiple orders to an existing outcome that has an orders at those price points',
+    assertions: () => {
+      const newMarketState = {
+        test: 'test',
+        orderBook: {
+          Outcome1: [
+            {
+              type: 'bid',
+              price: createBigNumber(0.3),
+              quantity: createBigNumber(1),
+            },
+            {
+              type: 'ask',
+              price: createBigNumber(0.9),
+              quantity: createBigNumber(1),
+            },
+          ],
+        },
+      }
+
+      const action1 = newMarket(newMarketState, {
+        type: ADD_ORDER_TO_NEW_MARKET,
+        data: {
+          outcome: 'Outcome1',
+          type: 'bid',
+          price: createBigNumber(0.3),
+          quantity: createBigNumber(1),
+        },
+      })
+
+      const action2 = newMarket(action1, {
+        type: ADD_ORDER_TO_NEW_MARKET,
+        data: {
+          outcome: 'Outcome1',
+          type: 'ask',
+          price: createBigNumber(0.9),
+          quantity: createBigNumber(5),
+        },
+      })
+
+      const actual = newMarket(action2, {
+        type: ADD_ORDER_TO_NEW_MARKET,
+        data: {
+          outcome: 'Outcome1',
+          type: 'bid',
+          price: createBigNumber(0.3),
+          quantity: createBigNumber(5),
+        },
+      })
+
+      const expected = {
+        test: 'test',
+        orderBook: {
+          Outcome1: [
+            {
+              type: 'bid',
+              price: createBigNumber(0.3),
+              quantity: createBigNumber(7),
+            },
+            {
+              type: 'ask',
+              price: createBigNumber(0.9),
+              quantity: createBigNumber(6),
+            },
+          ],
+        },
+      }
+
+      assert.deepEqual(actual, expected, `Didn't return the expected orderBook object`)
+    },
+  })
+
+  test({
     describe: 'should remove order',
     assertions: () => {
       const newMarketState = {


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/14213/market-liquidity-order-price-grouping

Groups market liquidity orders by outcome/type/price so we don't end up with an orderbook state like so:

```
BIDS:
1 @ .5
3 @ .5
2 @ .5
```

now that same sequence of orders placed with the same price point would result in this:
```
BIDS:
6 @ .5
```
and only require 1 transaction to send, instead of 3, which will save on gas costs/time.