### PR TITLE
Enable auto login when running integration

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -11,6 +11,7 @@ process.env.FORCE_COLOR = true;
 
 const FLAGS = JSON.parse(process.env.npm_config_argv).original.filter(arg => arg.indexOf('--') !== -1);
 process.env.USE_SSL = FLAGS.indexOf('--ssl') !== -1 ? true : false;
+process.env.AUTO_LOGIN = FLAGS.indexOf('--auto-login') !== -1 ? true : false;
 
 // START DEVELOPMENT SERVER
 //	NOTE -- this will also automatically spin up webpack w/ HMR (Hot Module Reload)

--- a/src/modules/app/actions/init-augur.js
+++ b/src/modules/app/actions/init-augur.js
@@ -52,7 +52,7 @@ function loadAccount(dispatch, existing, env, callback) {
     let account = existing
     if (existing !== accounts[0]) {
       account = accounts[0]
-      if (account && env.useWeb3Transport) {
+      if (account && (env.useWeb3Transport || process.env.AUTO_LOGIN)) {
         dispatch(useUnlockedAccount(account))
       } else {
         dispatch(logout())

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,6 +153,7 @@ let config = {
         GETH_PASSWORD: JSON.stringify(process.env.GETH_PASSWORD),
         ETHEREUM_NETWORK: JSON.stringify(process.env.ETHEREUM_NETWORK || 'dev'),
         CURRENT_BRANCH: JSON.stringify(gitRevisionPlugin.branch()),
+        AUTO_LOGIN: JSON.stringify(process.env.AUTO_LOGIN || false),
 
         // Set this var to remove code that is problematic for us to host.
         // Will need to be negated in the relevant conditionals.


### PR DESCRIPTION
[CH Issue](https://app.clubhouse.io/augur/story/14312/enable-auto-login-when-running-integration-tests)
All of the integration tests are broken due to the UI forcing the user to connect an account. This PR allows an --auto-login flag to be passed in like: `yarn dev --auto-login` so that the integration tests can then be run.