### PR TITLE
don't show no-rep balance when user isn't logged in. some not in use …

### DIFF
--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
@@ -25,7 +25,6 @@ export default class ReportingDisputeMarkets extends Component {
     isConnected: PropTypes.bool.isRequired,
     loadMarkets: PropTypes.func.isRequired,
     outcomes: PropTypes.object.isRequired,
-    account: PropTypes.string.isRequired,
     isForking: PropTypes.bool.isRequired,
     forkingMarketId: PropTypes.string.isRequired,
     pageinationCount: PropTypes.number.isRequired,

--- a/src/modules/reporting/containers/reporting-dispute-markets.js
+++ b/src/modules/reporting/containers/reporting-dispute-markets.js
@@ -20,7 +20,7 @@ const mapStateToProps = (state, { history }) => {
   return ({
     isLogged: state.isLogged,
     isConnected: state.connection.isConnected && state.universe.id != null,
-    doesUserHaveRep: (loginAccount.rep.value > 0),
+    doesUserHaveRep: (loginAccount.rep.value > 0 || !state.isLogged),
     markets: disputableMarkets,
     showPagination: disputableMarkets.length > PAGINATION_COUNT,
     disputableMarketsLength: disputableMarkets.length,
@@ -31,7 +31,6 @@ const mapStateToProps = (state, { history }) => {
     isMobile: state.isMobile,
     navigateToAccountDepositHandler: () => history.push(makePath(ACCOUNT_DEPOSIT)),
     outcomes: disputeOutcomes,
-    account: loginAccount.address,
     isForking: state.universe.isForking,
     forkEndTime: state.universe.forkEndTime,
     forkingMarketId: state.universe.forkingMarket,


### PR DESCRIPTION
…prop type clean up


https://app.clubhouse.io/augur/story/14381/no-rep-message-should-not-be-visible-when-not-logged-in