### PR TITLE
refresh users rep staked on fee window when transfer token event happ…

### DIFF
--- a/src/modules/events/actions/log-handlers.js
+++ b/src/modules/events/actions/log-handlers.js
@@ -65,6 +65,7 @@ export const handleTokensMintedLog = log => (dispatch, getState) => {
   const { address } = getState().loginAccount
   const isStoredTransaction = log.target === address
   if (isStoredTransaction) {
+    dispatch(loadReportingWindowBounds())
     dispatch(defaultLogHandler(log))
   }
 }

--- a/test/events/actions/log-handlers-test.js
+++ b/test/events/actions/log-handlers-test.js
@@ -12,11 +12,12 @@ describe('modules/events/actions/log-handlers.js', () => {
   })
 
   describe('handleCompleteSetsSoldLog', () => {
-    const { handleCompleteSetsSoldLog, __RewireAPI__ } = require('modules/events/actions/log-handlers.js')
+    const { handleTokensMintedLog, handleCompleteSetsSoldLog, __RewireAPI__ } = require('modules/events/actions/log-handlers.js')
 
     const ACTIONS = {
       LOAD_ACCOUNT_TRADES: 'LOAD_ACCOUNT_TRADES',
       UPDATE_LOGGED_TRANSACTIONS: 'UPDATE_LOGGED_TRANSACTIONS',
+      LOAD_REPORTING_WINDOW: 'LOAD_REPORTING_WINDOW',
     }
 
     beforeEach(() => {
@@ -32,11 +33,15 @@ describe('modules/events/actions/log-handlers.js', () => {
           marketId: options.marketId,
         },
       }))
+      __RewireAPI__.__Rewire__('loadReportingWindowBounds', log => ({
+        type: ACTIONS.LOAD_REPORTING_WINDOW,
+      }))
     })
 
     afterEach(() => {
       __RewireAPI__.__ResetDependency__('loadAccountTrades')
       __RewireAPI__.__ResetDependency__('updateLoggedTransactions')
+      __RewireAPI__.__ResetDependency__('loadReportingWindowBounds')
     })
 
 
@@ -68,9 +73,6 @@ describe('modules/events/actions/log-handlers.js', () => {
           },
         }]
 
-
-        console.log(actual)
-
         assert.deepEqual(actual, expected, `Dispatched unexpected actions.`)
       },
     })
@@ -93,6 +95,25 @@ describe('modules/events/actions/log-handlers.js', () => {
 
         const expected = []
 
+        assert.deepEqual(actual, expected, `Dispatched unexpected actions.`)
+      },
+    })
+
+    test({
+      description: `should process token mint log`,
+      state: {
+        loginAccount: {
+          address: '0xb0b',
+        },
+      },
+      assertions: (store) => {
+        const log = {
+          marketId: '0xdeadbeef',
+          target: '0xb0b',
+        }
+        store.dispatch(handleTokensMintedLog(log))
+        const actual = store.getActions()
+        const expected = [{ type: ACTIONS.LOAD_REPORTING_WINDOW }]
         assert.deepEqual(actual, expected, `Dispatched unexpected actions.`)
       },
     })


### PR DESCRIPTION
…ends, which happens when users transfer rep for pt


https://app.clubhouse.io/augur/story/13946/participation-tokens-balance-not-dynamically-updated-in-ui