### PR TITLE
johndanz/ch14234/update-additional-details

### DIFF
--- a/src/modules/create-market/components/create-market-form-review/create-market-form-review.jsx
+++ b/src/modules/create-market/components/create-market-form-review/create-market-form-review.jsx
@@ -112,7 +112,9 @@ export default class CreateMarketReview extends Component {
         this.updateFunds(insufficientFundsString)
       }
     }
-
+    if (this.additionalDetails && this.additionalDetails.scrollHeight) {
+      this.additionalDetails.style.height = `${this.additionalDetails.scrollHeight}px`
+    }
     return (
       <article className={StylesForm.CreateMarketForm__fields}>
         <div className={Styles.CreateMarketReview}>
@@ -166,7 +168,13 @@ export default class CreateMarketReview extends Component {
           </div>
           <div className={Styles.CreateMarketReview__addedDetails}>
             <h4 className={Styles.CreateMarketReview__smallheading}>Additional Details</h4>
-            <p className={Styles.CreateMarketReview__smallparagraph}>{newMarket.detailsText || 'None'}</p>
+            <textarea
+              ref={(additionalDetails) => { this.additionalDetails = additionalDetails }}
+              className={Styles['CreateMarketReview__AdditionalDetails-text']}
+              disabled
+              readOnly
+              value={newMarket.detailsText || 'None'}
+            />
           </div>
         </div>
       </article>

--- a/src/modules/create-market/components/create-market-form-review/create-market-form-review.styles.less
+++ b/src/modules/create-market/components/create-market-form-review/create-market-form-review.styles.less
@@ -5,6 +5,17 @@
   width: 36rem;
 }
 
+.CreateMarketReview__AdditionalDetails-text,
+.CreateMarketReview__AdditionalDetails-text:disabled {
+  background: none;
+  border: 0;
+  color: @color-lightgray;
+  margin: 0 0 2rem;
+  overflow: hidden;
+  padding: 0;
+  resize: none;
+}
+
 .CreateMarketReview__heading {
   &:extend(.caps--large);
 

--- a/src/modules/create-market/components/create-market-form/create-market-form.styles.less
+++ b/src/modules/create-market/components/create-market-form/create-market-form.styles.less
@@ -164,7 +164,7 @@
     }
 
     textarea {
-      height: 3.5rem;
+      height: 9.5rem;
       padding-top: 1rem;
     }
 

--- a/src/modules/market/components/market-header/market-header.jsx
+++ b/src/modules/market/components/market-header/market-header.jsx
@@ -53,7 +53,9 @@ export default class MarketHeader extends Component {
     const s = this.state
     const detailsPresent = (details != null && details.length > 0) || (marketType === SCALAR)
     const denomination = scalarDenomination ? ' ' + scalarDenomination : ''
-
+    if (this.additionalDetails && this.additionalDetails.scrollHeight) {
+      this.additionalDetails.style.height = `${this.additionalDetails.scrollHeight}px`
+    }
     return (
       <section className={Styles.MarketHeader}>
         <div className={Styles.MarketHeader__nav}>
@@ -158,7 +160,13 @@ export default class MarketHeader extends Component {
               className={details ? Styles.MarketHeader__details : Styles.MarketHeader__no_details}
             >
               { details &&
-                <span>{details}</span>
+                <textarea
+                  ref={(additionalDetails) => { this.additionalDetails = additionalDetails }}
+                  className={Styles['MarketHeader__AdditionalDetails-text']}
+                  disabled
+                  readOnly
+                  value={details}
+                />
               }
               { marketType === SCALAR &&
               <p>

--- a/src/modules/market/components/market-header/market-header.styles.less
+++ b/src/modules/market/components/market-header/market-header.styles.less
@@ -9,6 +9,17 @@
   margin-top: 2rem;
 }
 
+.MarketHeader__AdditionalDetails-text,
+.MarketHeader__AdditionalDetails-text:disabled {
+  background: none;
+  border: 0;
+  color: @color-lightgray;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  resize: none;
+}
+
 .MarketHeader__nav {
   margin: 0 0 1rem;
 }
@@ -129,7 +140,7 @@
 
 .MarketHeader__no_details,
 .MarketHeader__details {
-  max-height: 200px;
+  // max-height: 200px;
   overflow-y: auto;
   padding: 1em;
 

--- a/src/modules/reporting/components/market-additional-details/market-additional-details.jsx
+++ b/src/modules/reporting/components/market-additional-details/market-additional-details.jsx
@@ -6,13 +6,21 @@ import { SCALAR } from 'modules/markets/constants/market-types'
 const MarketAdditonalDetails = (p) => {
   const { details, resolutionSource, marketType, minPrice, maxPrice, scalarDenomination } = p.market
   const denomination = scalarDenomination ? ' ' + scalarDenomination : ''
-
+  if (this.additionalDetails && this.additionalDetails.scrollHeight) {
+    this.additionalDetails.style.height = `${this.additionalDetails.scrollHeight}px`
+  }
   return (
     <article>
       <div className={Styles[`MarketAdditionalDetails__details-wrapper`]}>
         <div className={Styles[`MarketAdditionalDetails__details-container`]}>
           { details &&
-            <p className={Styles[`MarketAdditionalDetails__details-details-text`]}>{details}</p>
+            <textarea
+              ref={(additionalDetails) => { this.additionalDetails = additionalDetails }}
+              className={Styles[`MarketAdditionalDetails__details-details-text`]}
+              disabled
+              readOnly
+              value={details}
+            />
           }
           <h4>Resolution Source:</h4>
           <span>{resolutionSource ? <a href={resolutionSource} target="_blank" rel="noopener noreferrer">{resolutionSource}</a> : 'General knowledge'}</span>

--- a/src/modules/reporting/components/market-additional-details/market-additional-details.style.less
+++ b/src/modules/reporting/components/market-additional-details/market-additional-details.style.less
@@ -27,8 +27,15 @@
   margin-bottom: 0;
 }
 
-.MarketAdditionalDetails__details-details-text {
-  margin-top: 0;
+.MarketAdditionalDetails__details-details-text,
+.MarketAdditionalDetails__details-details-text:disabled {
+  background: none;
+  border: 0;
+  color: @color-lightgray;
+  margin: 0 0 1rem;
+  overflow: hidden;
+  padding: 0;
+  resize: none;
 }
 
 @media @breakpoint-mobile-medium {


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/14234/update-additional-details

Two things here, in create-market we made the additional details textbox 3x the height basically so that it's more clear you can put in lots of text if you want. 

On the trading page, the additional details dropdown should now allow for line breaks, but still disallow XSS attacks.