### PR TITLE
only show designated reporting things if address is valid

### DIFF
--- a/src/modules/reporting/actions/load-reporting.js
+++ b/src/modules/reporting/actions/load-reporting.js
@@ -23,7 +23,7 @@ export const loadReporting = (callback = logError) => (dispatch, getState) => {
     },
     (err, marketIds) => {
       if (err) return callback(err)
-      if (!marketIds || marketIds.length === 0) {
+      if (!marketIds || marketIds.length === 0 || isNaN(loginAccount.address)) {
         dispatch(updateUpcomingDesignatedReportingMarkets([]))
         return callback(null)
       }
@@ -44,7 +44,7 @@ export const loadReporting = (callback = logError) => (dispatch, getState) => {
     },
     (err, marketIds) => {
       if (err) return callback(err)
-      if (!marketIds || marketIds.length === 0) {
+      if (!marketIds || marketIds.length === 0 || isNaN(loginAccount.address)) {
         dispatch(updateDesignatedReportingMarkets([]))
         return callback(null)
       }


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/14471/upcoming-reporting-markets-isn-t-restricted

we don't want to show any designated report markets in upcoming markets or designated report sections when the user is not logged in.