### PR TITLE
Default candlestick chart to days by weeks

### DIFF
--- a/src/modules/market/constants/permissible-periods.js
+++ b/src/modules/market/constants/permissible-periods.js
@@ -22,12 +22,12 @@ export const RANGES = [
   {
     duration: 86400,
     label: 'Past day',
-    isDefault: true,
     tickInterval: axis => axis.ticks(timeHour.every(3)),
   },
   {
     duration: 604800,
     label: 'Past week',
+    isDefault: true,
     tickInterval: axis => axis.ticks(timeDay.every(1)),
   },
   {
@@ -55,11 +55,11 @@ export const
     {
       duration: 3600,
       label: 'Hourly',
-      isDefault: true,
     },
     {
       duration: 86400,
       label: 'Daily',
+      isDefault: true,
     },
     {
       duration: 604800,


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/14247/default-candlestick-zoom-should-be-different

![image](https://user-images.githubusercontent.com/328965/43219411-117226a8-8ffc-11e8-808b-6fedd7fe0bef.png)
