### PR TITLE
added defensive code just in case user wants to buy participation tok…

### DIFF
--- a/src/modules/reporting/actions/purchase-participation-tokens.js
+++ b/src/modules/reporting/actions/purchase-participation-tokens.js
@@ -10,7 +10,7 @@ export const purchaseParticipationTokens = (amount, estimateGas = false, callbac
   augur.reporting.getFeeWindowCurrent({ universe: universe.id }, (err, currFeeWindowInfo) => {
     if (err) return callback(err)
     let methodFunc = augur.api.FeeWindow.buy
-    let address = currFeeWindowInfo.feeWindow
+    let address = currFeeWindowInfo ? currFeeWindowInfo.feeWindow : null
     if (address == null) {
       methodFunc = augur.api.Universe.buyParticipationTokens
       address = universe.id

--- a/test/reporting/actions/purchase-participation-tokens-test.js
+++ b/test/reporting/actions/purchase-participation-tokens-test.js
@@ -170,4 +170,38 @@ describe('purchase participation tokens tests', () => {
       }))
     },
   })
+
+  test({
+    description: 'It should handle an null current Fee Window',
+    assertions: (done) => {
+      ReWireModule.__Rewire__('augur', {
+        api: {
+          FeeWindow: {
+            buy: (p) => {
+              assert.isNull('we should never hit this.')
+            },
+          },
+          Universe: {
+            buyParticipationTokens: (p) => { p.onSuccess('10.25') },
+          },
+        },
+        reporting: {
+          getFeeWindowCurrent: (p, cb) => {
+            assert.deepEqual(p, { universe: store.getState().universe.id })
+            assert.isFunction(cb)
+            cb(null)
+          },
+        },
+        rpc: mockRPC,
+      })
+
+      store.dispatch(purchaseParticipationTokens('10.25', false, (err, res) => {
+        assert.isNull(err)
+        assert.deepEqual(res, '10.25')
+        const expectedActions = []
+        assert.deepEqual(store.getActions(), expectedActions)
+        done()
+      }))
+    },
+  })
 })


### PR DESCRIPTION
…ens but the current fee winoow hasn't been created

https://app.clubhouse.io/augur/story/14519/buying-pts-should-create-a-new-fee-window-if-necessary


adding defensive code, wasn't able to repro the issue on private change.