### PR TITLE
johndanz/ch14662/github-market-liquidity-on-review-page-is

### DIFF
--- a/src/modules/create-market/components/create-market-form-liquidity/create-market-form-liquidity.jsx
+++ b/src/modules/create-market/components/create-market-form-liquidity/create-market-form-liquidity.jsx
@@ -20,7 +20,6 @@ import Styles from 'modules/create-market/components/create-market-form-liquidit
 import StylesForm from 'modules/create-market/components/create-market-form/create-market-form.styles'
 
 const PRECISION = 4
-const NEW_ORDER_GAS_ESTIMATE = createBigNumber(700000)
 
 export default class CreateMarketLiquidity extends Component {
 
@@ -34,6 +33,7 @@ export default class CreateMarketLiquidity extends Component {
     keyPressed: PropTypes.func.isRequired,
     liquidityState: PropTypes.object.isRequired,
     updateState: PropTypes.func.isRequired,
+    updateInitialLiquidityCosts: PropTypes.func.isRequired,
   }
 
   static formatOrderValue(orderValue) {
@@ -69,7 +69,7 @@ export default class CreateMarketLiquidity extends Component {
     this.updatePriceBounds = this.updatePriceBounds.bind(this)
     this.updateSeries = this.updateSeries.bind(this)
     this.sortOrderBook = this.sortOrderBook.bind(this)
-    this.updateInitialLiquidityCosts = this.updateInitialLiquidityCosts.bind(this)
+    // this.updateInitialLiquidityCosts = this.updateInitialLiquidityCosts.bind(this)
     this.validateForm = this.validateForm.bind(this)
     this.updateOrderEstimate = this.updateOrderEstimate.bind(this)
     this.updateLiquidityState = this.updateLiquidityState.bind(this)
@@ -123,7 +123,10 @@ export default class CreateMarketLiquidity extends Component {
   }
 
   handleAddOrder() {
-    const { addOrderToNewMarket } = this.props
+    const {
+      addOrderToNewMarket,
+      updateInitialLiquidityCosts,
+    } = this.props
     if (this.state.isOrderValid) {
       addOrderToNewMarket({
         outcome: this.state.selectedOutcome,
@@ -133,7 +136,7 @@ export default class CreateMarketLiquidity extends Component {
         orderEstimate: this.state.orderEstimate,
       })
 
-      this.updateInitialLiquidityCosts({
+      updateInitialLiquidityCosts({
         type: this.state.selectedNav,
         price: this.state.orderPrice,
         quantity: this.state.orderQuantity,
@@ -255,58 +258,6 @@ export default class CreateMarketLiquidity extends Component {
     }, {})
 
     updateNewMarket({ orderBookSeries })
-  }
-
-  updateInitialLiquidityCosts(order, shouldReduce) {
-    const {
-      availableEth,
-      newMarket,
-      updateNewMarket,
-    } = this.props
-    const minPrice = newMarket.type === SCALAR ? newMarket.scalarSmallNum : 0
-    const maxPrice = newMarket.type === SCALAR ? newMarket.scalarBigNum : 1
-    const shareBalances = newMarket.outcomes.map(outcome => 0)
-    let outcome
-    let initialLiquidityEth
-    let initialLiquidityGas
-
-    switch (newMarket.type) {
-      case CATEGORICAL:
-        newMarket.outcomes.forEach((outcomeName, index) => {
-          if (this.state.selectedOutcome === outcomeName) outcome = index
-        })
-        break
-      case SCALAR:
-        outcome = this.state.selectedOutcome
-        break
-      default:
-        outcome = 1
-    }
-
-    const orderInfo = {
-      orderType: order.type === BID ? 0 : 1,
-      outcome,
-      shares: order.quantity,
-      price: order.price,
-      tokenBalance: availableEth,
-      minPrice,
-      maxPrice,
-      marketCreatorFeeRate: newMarket.settlementFee,
-      reportingFeeRate: 0,
-      shareBalances,
-      singleOutcomeOrderBook: newMarket.orderBook[outcome] || {},
-    }
-    const action = augur.trading.simulateTrade(orderInfo)
-    // NOTE: Fees are going to always be 0 because we are only opening orders, and there is no costs associated with opening orders other than the escrowed ETH and the gas to put the order up.
-    if (shouldReduce) {
-      initialLiquidityEth = newMarket.initialLiquidityEth.minus(action.tokensDepleted)
-      initialLiquidityGas = newMarket.initialLiquidityGas.minus(NEW_ORDER_GAS_ESTIMATE)
-    } else {
-      initialLiquidityEth = newMarket.initialLiquidityEth.plus(action.tokensDepleted)
-      initialLiquidityGas = newMarket.initialLiquidityGas.plus(NEW_ORDER_GAS_ESTIMATE)
-    }
-
-    updateNewMarket({ initialLiquidityEth, initialLiquidityGas })
   }
 
   validateForm(orderQuantityRaw, orderPriceRaw) {


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/14662/github-market-liquidity-on-review-page-is-incorrect-if-it-s-adjusted

fixed a situation where canceled orders didn't remove the amount of ETH in the estimate for the value of the order.