### PR TITLE
set correct valid fee range from 0 to 50

### DIFF
--- a/src/modules/create-market/components/create-market-form-liquidity/create-market-form-liquidity.jsx
+++ b/src/modules/create-market/components/create-market-form-liquidity/create-market-form-liquidity.jsx
@@ -391,7 +391,7 @@ export default class CreateMarketLiquidity extends Component {
               type="number"
               value={newMarket.settlementFee}
               placeholder="0"
-              onChange={e => validateNumber('settlementFee', e.target.value, 'market creator fee', 0, 100, 2)}
+              onChange={e => validateNumber('settlementFee', e.target.value, 'market creator fee', 0, 50, 2)}
               onKeyPress={e => keyPressed(e)}
             />
             <span className={Styles.CreateMarketLiquidity__settlementFeePercent}>%</span>


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/11333/creating-markets-allows-user-to-specify-50-fee-causing-market-creation-failure