### PR TITLE
remove input number spinners

### DIFF
--- a/src/modules/forking/components/migrate-rep-form/migrate-rep-form.jsx
+++ b/src/modules/forking/components/migrate-rep-form/migrate-rep-form.jsx
@@ -236,7 +236,7 @@ export default class MigrateRepForm extends Component {
                     step={market.tickSize}
                     placeholder={market.scalarDenomination}
                     value={inputSelectedOutcome}
-                    className={classNames({ [`${FormStyles['Form__error--field']}`]: validations.hasOwnProperty('err') && validations.selectedOutcome })}
+                    className={classNames(FormStyles.Form__input, { [`${FormStyles['Form__error--field']}`]: validations.hasOwnProperty('err') && validations.selectedOutcome })}
                     onChange={(e) => { this.validateScalar(e.target.value, 'outcome', market.minPrice, market.maxPrice, market.tickSize, false) }}
                   />
                 </li>

--- a/src/modules/modal/components/modal-participate/modal-participate.jsx
+++ b/src/modules/modal/components/modal-participate/modal-participate.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { createBigNumber } from 'utils/create-big-number'
-
+import FormStyles from 'modules/common/less/form'
 import { Participate, ExclamationCircle as InputErrorIcon } from 'modules/common/components/icons'
 import Styles from 'modules/modal/components/modal-participate/modal-participate.styles'
 import Input from 'modules/common/components/input/input'
@@ -127,7 +127,7 @@ export default class ModalParticipate extends Component {
             <Input
               id="modal__participate-quantity"
               type="number"
-              className={classNames({ [`${Styles['ModalParticipate__error--field']}`]: invalidWithErrors })}
+              className={classNames(FormStyles.Form__input, { [`${Styles['ModalParticipate__error--field']}`]: invalidWithErrors })}
               value={s.quantity}
               placeholder="0.0"
               onChange={value => this.updateQuantity(value)}

--- a/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
+++ b/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
@@ -424,7 +424,7 @@ export default class ReportingDisputeForm extends Component {
                       step={market.tickSize}
                       placeholder={market.scalarDenomination}
                       value={s.inputSelectedOutcome}
-                      className={classNames({ [`${FormStyles['Form__error--field']}`]: s.validations.hasOwnProperty('err') && s.validations.selectedOutcome })}
+                      className={classNames(FormStyles.Form__input, { [`${FormStyles['Form__error--field']}`]: s.validations.hasOwnProperty('err') && s.validations.selectedOutcome })}
                       onChange={(e) => { this.validateScalar(e.target.value, 'outcome', market.minPrice, market.maxPrice, market.tickSize, false) }}
                     />
                     <ReportingDisputeProgress

--- a/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
+++ b/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
@@ -200,7 +200,7 @@ export default class ReportingReportForm extends Component {
                   step={market.tickSize}
                   placeholder={market.scalarDenomination}
                   value={s.inputSelectedOutcome}
-                  className={classNames({ [`${FormStyles['Form__error--field']}`]: validations.hasOwnProperty('err') && validations.selectedOutcome })}
+                  className={classNames(FormStyles.Form__input, { [`${FormStyles['Form__error--field']}`]: validations.hasOwnProperty('err') && validations.selectedOutcome })}
                   onChange={(e) => { this.validateScalar(validations, e.target.value, 'outcome', market.minPrice, market.maxPrice, market.tickSize, false) }}
                 />
               </li>

--- a/src/modules/trade/components/trading--form/trading--form.jsx
+++ b/src/modules/trade/components/trading--form/trading--form.jsx
@@ -11,7 +11,7 @@ import { isEqual } from 'lodash'
 import ReactTooltip from 'react-tooltip'
 import TooltipStyles from 'modules/common/less/tooltip'
 import { Hint } from 'modules/common/components/icons'
-
+import FormStyles from 'modules/common/less/form'
 import Styles from 'modules/trade/components/trading--form/trading--form.styles'
 import { formatEther, formatShares } from 'utils/format-number'
 import Checkbox from 'src/modules/common/components/checkbox/checkbox'
@@ -293,7 +293,7 @@ class MarketTradingForm extends Component {
           <li>
             <label htmlFor="tr__input--total-cost">Total Cost</label>
             <input
-              className={classNames({ [`${Styles.error}`]: s.errors[this.INPUT_TYPES.MARKET_ORDER_SIZE].length })}
+              className={classNames(FormStyles.Form__input, { [`${Styles.error}`]: s.errors[this.INPUT_TYPES.MARKET_ORDER_SIZE].length })}
               id="tr__input--total-cost"
               type="number"
               step={tickSize}
@@ -348,7 +348,7 @@ class MarketTradingForm extends Component {
             <li className={Styles['TradingForm__limit-quantity']}>
               <label htmlFor="tr__input--quantity">Quantity</label>
               <input
-                className={classNames({ [`${Styles.error}`]: s.errors[this.INPUT_TYPES.QUANTITY].length })}
+                className={classNames(FormStyles.Form__input, { [`${Styles.error}`]: s.errors[this.INPUT_TYPES.QUANTITY].length })}
                 id="tr__input--quantity"
                 type="number"
                 step={tickSize}
@@ -360,7 +360,7 @@ class MarketTradingForm extends Component {
             <li className={Styles['TradingForm__limit-price']}>
               <label htmlFor="tr__input--limit-price">Limit Price</label>
               <input
-                className={classNames({ [`${Styles.error}`]: s.errors[this.INPUT_TYPES.PRICE].length })}
+                className={classNames(FormStyles.Form__input, { [`${Styles.error}`]: s.errors[this.INPUT_TYPES.PRICE].length })}
                 id="tr__input--limit-price"
                 type="number"
                 step={tickSize}


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/11544/remove-up-down-arrows-from-inputs

remove the input spinners (up/down arrows) from 
buy participation form
initial reporting on scalar market
scalar dispute form
migrate rep form