### PR TITLE
yea, changed calculate proceeds to finalize market, removed sorting b…

### DIFF
--- a/src/modules/market/components/market-portfolio-card/market-portfolio-card.jsx
+++ b/src/modules/market/components/market-portfolio-card/market-portfolio-card.jsx
@@ -83,7 +83,7 @@ export default class MarketPortfolioCard extends Component {
         buttonAction = this.claimProceeds
         break
       case TYPE_FINALIZE_MARKET:
-        localButtonText = 'Calculate Payout'
+        localButtonText = 'Finalize Market'
         buttonAction = this.finalizeMarket
         break
       default:

--- a/src/modules/my-markets/selectors/my-markets.js
+++ b/src/modules/my-markets/selectors/my-markets.js
@@ -6,7 +6,7 @@ import { selectLoginAccountAddress, selectPriceHistoryState, selectMarketCreator
 import selectAllMarkets from 'modules/markets/selectors/markets-all'
 import { ZERO } from 'modules/trade/constants/numbers'
 import { formatNumber, formatEther } from 'utils/format-number'
-import { sortBy } from 'lodash'
+import { orderBy } from 'lodash'
 
 export default function () {
   return selectLoginAccountMarkets(store.getState())
@@ -47,9 +47,7 @@ export const selectLoginAccountMarkets = createSelector(
       })
     })
 
-    sortBy(markets, ['finalizationTime', 'endTime'])
-
-    return markets
+    return orderBy(markets, ['endTime.timestamp'], ['desc'])
   },
 )
 

--- a/src/modules/portfolio/containers/positions.js
+++ b/src/modules/portfolio/containers/positions.js
@@ -32,7 +32,7 @@ const mapStateToProps = (state) => {
     }
   })
 
-  const orderdClosedMarkets = orderBy(closedMarkets, ['reportingState', 'endTime.timestamp'], ['asc', 'desc'])
+  const orderdClosedMarkets = orderBy(closedMarkets, ['endTime.timestamp'], ['desc'])
 
   return {
     currentTimestamp: selectCurrentTimestamp(state),


### PR DESCRIPTION
…y finalization time, only sort by endTime on positions view

https://app.clubhouse.io/augur/story/15386/markets-moving-when-finalized-could-confuse-users


2 changes
1. change calculate proceeds to finalize market
2. sort by endtime on positions page.