### PR TITLE
Achapman/ch14661/GitHub unable to claim outstanding returns

### DIFF
--- a/src/modules/my-positions/actions/claim-trading-proceeds.js
+++ b/src/modules/my-positions/actions/claim-trading-proceeds.js
@@ -17,7 +17,7 @@ const claimTradingProceeds = (marketIds, callback = logError) => (dispatch, getS
   if (markets.length > 0) {
     each(markets, (marketId) => {
       augur.api.ClaimTradingProceeds.claimTradingProceeds({
-        tx: { gas: CLAIM_SHARES_GAS_COST },
+        tx: { gas: CLAIM_SHARES_GAS_COST, returns: "null" },
         meta: loginAccount.meta,
         _market: marketId,
         _shareHolder: loginAccount.address,

--- a/src/modules/my-positions/actions/claim-trading-proceeds.js
+++ b/src/modules/my-positions/actions/claim-trading-proceeds.js
@@ -19,7 +19,7 @@ const claimTradingProceeds = (marketIds, callback = logError) => (dispatch, getS
   if (markets.length > 0) {
     each(markets, (marketId) => {
       augur.api.ClaimTradingProceeds.claimTradingProceeds({
-        tx: { gas: CLAIM_SHARES_GAS_COST, returns: "null" },
+        tx: { gas: CLAIM_SHARES_GAS_COST, returns: 'null' },
         meta: loginAccount.meta,
         _market: marketId,
         _shareHolder: loginAccount.address,

--- a/src/modules/my-positions/actions/claim-trading-proceeds.js
+++ b/src/modules/my-positions/actions/claim-trading-proceeds.js
@@ -7,6 +7,8 @@ import { getWinningBalance } from 'modules/portfolio/actions/get-winning-balance
 import noop from 'utils/noop'
 import logError from 'utils/log-error'
 
+// Note: the returns: "null" is due to this geth bug: https://github.com/ethereum/go-ethereum/issues/16999. By including this and a hardcoded gas estimate we bypass any eth_call usage and avoid sprurious failures
+
 const CLAIM_SHARES_GAS_COST = 3000000
 
 const claimTradingProceeds = (marketIds, callback = logError) => (dispatch, getState) => {


### PR DESCRIPTION
This allows us to prevent any eth_calls from happening here which is where the bug is. This should really never fail unless the market is not finalized so this shouldn't cause any problems.

I couldn't remove the hardcoded gas limit as apparently the estimateGas call can fail for the same reason (which makes sense actually since its just an eth_call under the hood).