### PR TITLE
johndanz/ch15039/canceled-orders-do-not-automatically-disappear

### DIFF
--- a/src/modules/events/actions/wrap-log-handler.js
+++ b/src/modules/events/actions/wrap-log-handler.js
@@ -6,7 +6,13 @@ export const wrapLogHandler = (logHandler = defaultLogHandler) => (dispatch, get
   if (log) {
     // console.info(`${new Date().toISOString()} LOG ${log.removed ? 'REMOVED' : 'ADDED'} ${log.eventName} ${JSON.stringify(log)}`)
     const universeId = getState().universe.id
-    const isInCurrentUniverse = find(Object.values(log), value => universeId === value)
-    if (isInCurrentUniverse) dispatch(logHandler(log))
+    if (Array.isArray(log)) {
+      log.forEach((log) => {
+        if (find(Object.values(log), value => universeId === value)) dispatch(logHandler(log))
+      })
+    } else {
+      const isInCurrentUniverse = find(Object.values(log), value => universeId === value)
+      if (isInCurrentUniverse) dispatch(logHandler(log))
+    }
   }
 }


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/15039/canceled-orders-do-not-automatically-disappear-from-open-orders-list

All the event logs are messed up, this is a high priority.

fixed log handler, at some point things where changed to emit an array of log objects, instead of each log object individually. This is causing the check, which assumes log is an object, to fail and not send the log to the log listeners, there by messing up all of our updating and causing canceled orders to stick around on the page until a refresh.


