### PR TITLE
don't allow users to type in negative quantity

### DIFF
--- a/src/modules/trade/components/trading--form/trading--form.jsx
+++ b/src/modules/trade/components/trading--form/trading--form.jsx
@@ -236,6 +236,12 @@ class MarketTradingForm extends Component {
     // since the order changed by user action, make sure we can place orders.
     // updateState('doNotCreateOrders', false)
     let value = rawValue
+    if (property === this.INPUT_TYPES.QUANTITY && (value === '' || createBigNumber(value).lt(0))) {
+      updateState(property, '')
+      return this.setState({
+        [property]: '',
+      })
+    }
     if (!(property === this.INPUT_TYPES.DO_NOT_CREATE_ORDERS) && !(BigNumber.isBigNumber(value)) && value !== '') value = createBigNumber(value, 10)
     const updatedState = {
       ...this.state,


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/11567/down-arrow-in-the-order-ticket-allows-user-to-enter-negative-number-should-never-go-below-zero-for-categorical-or-binary


clear quantity if user tries to type in negative quantity, even if they type in 9999 then -9999, clean textbox.