### PR TITLE
Tomhaile/ch11997/sort child universes to show winning universe

### DIFF
--- a/src/modules/account/components/account-universes/account-universes.jsx
+++ b/src/modules/account/components/account-universes/account-universes.jsx
@@ -39,11 +39,21 @@ export default class AccountUniverses extends Component {
       getUniverses,
     } = this.props
     getUniverses((universesInfo) => {
+
       const children = universesInfo.children.map(c => ({
         ...c,
         totalRep: formatAttoRep(c.supply, { decimals: 2, roundUp: true }).formattedValue,
       }))
       universesInfo.children = orderBy(children, ['totalRep'], ['desc'])
+
+
+      const currentLevel = universesInfo.currentLevel.map(c => ({
+        ...c,
+        totalRep: formatAttoRep(c.supply, { decimals: 2, roundUp: true }).formattedValue,
+      }))
+      universesInfo.currentLevel = orderBy(currentLevel, ['totalRep'], ['desc'])
+
+
       this.setState({
         universesInfo,
       })

--- a/src/modules/account/components/account-universes/account-universes.jsx
+++ b/src/modules/account/components/account-universes/account-universes.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 
 import Styles from 'modules/account/components/account-universes/account-universes.styles'
 import AccountUniverseDescription from '../account-universe-description/account-universe-description'
+import { formatAttoRep } from 'utils/format-number'
+import { orderBy } from 'lodash'
 
 export default class AccountUniverses extends Component {
 
@@ -37,6 +39,8 @@ export default class AccountUniverses extends Component {
       getUniverses,
     } = this.props
     getUniverses((universesInfo) => {
+      universesInfo.children.forEach(c => c.totalRep = formatAttoRep(c.supply, { decimals: 2, roundUp: true }).formattedValue)
+      universesInfo.children = orderBy(universesInfo.children, ['totalRep'], ['desc'])
       this.setState({
         universesInfo,
       })

--- a/src/modules/account/components/account-universes/account-universes.jsx
+++ b/src/modules/account/components/account-universes/account-universes.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
+import { orderBy } from 'lodash'
+import { formatAttoRep } from 'utils/format-number'
 import Styles from 'modules/account/components/account-universes/account-universes.styles'
 import AccountUniverseDescription from '../account-universe-description/account-universe-description'
-import { formatAttoRep } from 'utils/format-number'
-import { orderBy } from 'lodash'
 
 export default class AccountUniverses extends Component {
 
@@ -39,8 +39,11 @@ export default class AccountUniverses extends Component {
       getUniverses,
     } = this.props
     getUniverses((universesInfo) => {
-      universesInfo.children.forEach(c => c.totalRep = formatAttoRep(c.supply, { decimals: 2, roundUp: true }).formattedValue)
-      universesInfo.children = orderBy(universesInfo.children, ['totalRep'], ['desc'])
+      const children = universesInfo.children.map(c => ({
+        ...c,
+        totalRep: formatAttoRep(c.supply, { decimals: 2, roundUp: true }).formattedValue,
+      }))
+      universesInfo.children = orderBy(children, ['totalRep'], ['desc'])
       this.setState({
         universesInfo,
       })

--- a/src/modules/trade/components/trading--form/trading--form.jsx
+++ b/src/modules/trade/components/trading--form/trading--form.jsx
@@ -236,12 +236,6 @@ class MarketTradingForm extends Component {
     // since the order changed by user action, make sure we can place orders.
     // updateState('doNotCreateOrders', false)
     let value = rawValue
-    if (property === this.INPUT_TYPES.QUANTITY && (value === '' || createBigNumber(value).lt(0))) {
-      updateState(property, '')
-      return this.setState({
-        [property]: '',
-      })
-    }
     if (!(property === this.INPUT_TYPES.DO_NOT_CREATE_ORDERS) && !(BigNumber.isBigNumber(value)) && value !== '') value = createBigNumber(value, 10)
     const updatedState = {
       ...this.state,

--- a/src/modules/trade/components/trading--form/trading--form.jsx
+++ b/src/modules/trade/components/trading--form/trading--form.jsx
@@ -236,6 +236,12 @@ class MarketTradingForm extends Component {
     // since the order changed by user action, make sure we can place orders.
     // updateState('doNotCreateOrders', false)
     let value = rawValue
+    if (property === this.INPUT_TYPES.QUANTITY && (value === '' || createBigNumber(value).lt(0))) {
+      updateState(property, '')
+      return this.setState({
+        [property]: '',
+      })
+    }
     if (!(property === this.INPUT_TYPES.DO_NOT_CREATE_ORDERS) && !(BigNumber.isBigNumber(value)) && value !== '') value = createBigNumber(value, 10)
     const updatedState = {
       ...this.state,


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/11997/sort-child-universes-to-show-winning-universe-at-top


1. force a fork,
2. migrate a little rep to each universe
3. verify that REP supply is ordered descending on account universe page. 
4. finalize the fork and verify winning universe is at the top.