### PR TITLE
Tomhaile/ch10982/price history chart should show average price

### DIFF
--- a/src/modules/market/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles.less
+++ b/src/modules/market/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles.less
@@ -43,7 +43,7 @@
     .tick-line,
     .tick-line--midpoint {
       stroke: @color-gray;
-      stroke-width: 1px;
+      stroke-width: 2px;
     }
 
     .overlay {

--- a/src/modules/market/components/market-outcomes-chart/market-outcomes-chart.jsx
+++ b/src/modules/market/components/market-outcomes-chart/market-outcomes-chart.jsx
@@ -212,6 +212,25 @@ function determineDrawParams(options) {
   const containerWidth = drawContainer.clientWidth;
   const containerHeight = drawContainer.clientHeight;
 
+
+  const mmSecondsInHour = createBigNumber(3600 * 1000)
+  const mmSecondsInDay = createBigNumber(24).times(mmSecondsInHour)
+  const mmSecondsInWeek = createBigNumber(7).times(mmSecondsInDay)
+
+  const bnCurrentTimestamp = createBigNumber(currentTimestamp)
+  const bnCreationTimestamp = createBigNumber(creationTime)
+  const overWeekDuration = (bnCurrentTimestamp.minus(bnCreationTimestamp)).gt(mmSecondsInWeek)
+
+  let bucket = mmSecondsInDay
+  if (!overWeekDuration){
+    bucket = mmSecondsInHour
+  }
+
+  const bnRange = bnCurrentTimestamp.minus(bnCreationTimestamp)
+  const numBuckets = Math.ceil(bnRange.dividedBy(bucket).toNumber())
+  const xDomain = Array.from(new Array(numBuckets),(val, index) => Math.ceil((bnCreationTimestamp.plus(createBigNumber(index).times(bucket))).toNumber()));
+
+  /*
   const xDomain = outcomes.reduce(
     (p, outcome) => [
       ...p,
@@ -219,6 +238,7 @@ function determineDrawParams(options) {
     ],
     [creationTime, currentTimestamp]
   );
+  */
   const yDomain = [minPrice, maxPrice];
 
   const xScale = d3

--- a/src/modules/market/containers/market-outcomes-chart.js
+++ b/src/modules/market/containers/market-outcomes-chart.js
@@ -4,6 +4,7 @@ import MarketOutcomesChart from "modules/market/components/market-outcomes-chart
 
 import { selectMarket } from "modules/market/selectors/market";
 import { selectCurrentTimestamp } from "src/select-state";
+import { selectBucketedPriceTimeSeries } from "modules/market/selectors/select-bucketed-price-time-series";
 import { createBigNumber } from "src/utils/create-big-number";
 
 const mapStateToProps = (state, ownProps) => {
@@ -23,14 +24,24 @@ const mapStateToProps = (state, ownProps) => {
     .plus(adjusted)
     .toNumber();
 
+  const creationTimestamp = creationTime.value.getTime();
+  const currentTimestamp = selectCurrentTimestamp(state);
+  const hasPriceHistory = volume.formatted !== "0";
+  const bucketedPriceTimeSeries = selectBucketedPriceTimeSeries(
+    creationTimestamp,
+    currentTimestamp,
+    outcomes
+  );
+
   return {
-    creationTime: creationTime.value.getTime(),
-    currentTimestamp: selectCurrentTimestamp(state),
+    creationTime: creationTimestamp,
+    currentTimestamp,
     estimatedInitialPrice,
     maxPrice: maxPrice.toNumber(),
     minPrice: minPrice.toNumber(),
     outcomes,
-    hasPriceHistory: volume.formatted !== "0"
+    hasPriceHistory,
+    bucketedPriceTimeSeries
   };
 };
 

--- a/src/modules/market/selectors/select-bucketed-price-time-series.js
+++ b/src/modules/market/selectors/select-bucketed-price-time-series.js
@@ -28,7 +28,7 @@ export const selectBucketedPriceTimeSeries = (
       bnCreationTimestamp.plus(createBigNumber(index).times(bucket)).toNumber()
     )
   );
-
+  timeBuckets.push(currentTimestamp);
   const priceTimeSeries = outcomes.reduce((p, o) => {
     p[o.id] = splitTradesByTimeBucket(o.priceTimeSeries, timeBuckets);
     return p;

--- a/src/modules/market/selectors/select-bucketed-price-time-series.js
+++ b/src/modules/market/selectors/select-bucketed-price-time-series.js
@@ -1,0 +1,80 @@
+import { createBigNumber } from "utils/create-big-number";
+import { sortBy, last, each, pullAll } from "lodash";
+
+export const selectBucketedPriceTimeSeries = (
+  creationTime,
+  currentTimestamp,
+  outcomes
+) => {
+  const mmSecondsInHour = createBigNumber(3600 * 1000);
+  const mmSecondsInDay = createBigNumber(24).times(mmSecondsInHour);
+  const mmSecondsInWeek = createBigNumber(7).times(mmSecondsInDay);
+
+  const bnCurrentTimestamp = createBigNumber(currentTimestamp);
+  const bnCreationTimestamp = createBigNumber(creationTime);
+  const overWeekDuration = bnCurrentTimestamp
+    .minus(bnCreationTimestamp)
+    .gt(mmSecondsInWeek);
+
+  let bucket = mmSecondsInDay;
+  if (!overWeekDuration) {
+    bucket = mmSecondsInHour;
+  }
+
+  const bnRange = bnCurrentTimestamp.minus(bnCreationTimestamp);
+  const numBuckets = Math.ceil(bnRange.dividedBy(bucket).toNumber());
+  const timeBuckets = Array.from(new Array(numBuckets), (val, index) =>
+    Math.ceil(
+      bnCreationTimestamp.plus(createBigNumber(index).times(bucket)).toNumber()
+    )
+  );
+
+  const priceTimeSeries = outcomes.reduce((p, o) => {
+    p[o.id] = splitTradesByTimeBucket(o.priceTimeSeries, timeBuckets);
+    return p;
+  }, {});
+
+  return {
+    timeBuckets,
+    priceTimeSeries
+  };
+};
+
+function splitTradesByTimeBucket(priceTimeSeries, timeBuckets) {
+  if (!priceTimeSeries || priceTimeSeries.length === 0) return [];
+  if (!timeBuckets || timeBuckets.length === 0) return [];
+  let timeSeries = sortBy(priceTimeSeries, "timestamp").slice();
+
+  const series = [];
+  for (let i = 0; i < timeBuckets.length - 1; i++) {
+    const start = timeBuckets[i];
+    const end = timeBuckets[i + 1];
+    const result = getTradeInTimeRange(timeSeries, start, end);
+    if (result.trades.length > 0) series.push(last(result.trades));
+    timeSeries = result.trimmedTimeSeries;
+  }
+  return series;
+}
+
+function getTradeInTimeRange(timeSeries, startTime, endTime) {
+  const bucket = [];
+  if (!timeSeries || timeSeries.length === 0) {
+    return {
+      trades: bucket,
+      trimmedTimeSeries: timeSeries
+    };
+  }
+
+  each(timeSeries, p => {
+    const timestamp = createBigNumber(p.timestamp);
+    if (timestamp.gt(createBigNumber(endTime))) return;
+    if (timestamp.gte(startTime)) {
+      bucket.push(p);
+    }
+  });
+
+  return {
+    trimmedTimeSeries: pullAll(timeSeries, bucket),
+    trades: sortBy(bucket, "timestamp")
+  };
+}

--- a/test/market/selectors/select-bucketed-price-series-test.js
+++ b/test/market/selectors/select-bucketed-price-series-test.js
@@ -1,0 +1,174 @@
+import { selectBucketedPriceTimeSeries } from "modules/market/selectors/select-bucketed-price-time-series";
+
+describe(`modules/market/selectors/select-market-outcome-trading-indicator.js`, () => {
+  const market1Outcomes = [
+    {
+      id: 0,
+      priceTimeSeries: []
+    },
+    {
+      id: 1,
+      priceTimeSeries: []
+    }
+  ];
+  const market2Outcomes = [
+    {
+      id: 0,
+      priceTimeSeries: [
+        {
+          price: 0.1,
+          timestamp: 1533312111000
+        }
+      ]
+    },
+    {
+      id: 1,
+      priceTimeSeries: [
+        {
+          price: 0.1,
+          timestamp: 1533312111000
+        }
+      ]
+    }
+  ];
+
+  const market3Outcomes = [
+    {
+      id: 0,
+      priceTimeSeries: [
+        {
+          price: 0.1,
+          timestamp: 1533312111000
+        },
+        {
+          price: 0.2,
+          timestamp: 1533315711000
+        },
+        {
+          price: 0.3,
+          timestamp: 1533319310000
+        },
+        {
+          price: 0.6,
+          timestamp: 1533319310002
+        },
+        {
+          price: 0.5,
+          timestamp: 1533319310003
+        },
+        {
+          price: 0.4,
+          timestamp: 1533319310004
+        }
+      ]
+    },
+    {
+      id: 2,
+      priceTimeSeries: [
+        {
+          price: 0.1,
+          timestamp: 1533312111000
+        },
+        {
+          price: 0.2,
+          timestamp: 1533315711000
+        },
+        {
+          price: 0.3,
+          timestamp: 1533319310000
+        },
+        {
+          price: 0.6,
+          timestamp: 1533319310002
+        },
+        {
+          price: 0.5,
+          timestamp: 1533319310003
+        },
+        {
+          price: 0.4,
+          timestamp: 1533319310004
+        }
+      ]
+    }
+  ];
+
+  it(`no trades in categorical market`, () => {
+    const creationTimestamp = 1533312112000;
+    const currentTimestamp = 1533312312000;
+    const actual = selectBucketedPriceTimeSeries(
+      creationTimestamp,
+      currentTimestamp,
+      market1Outcomes
+    );
+    const expected = {
+      priceTimeSeries: { 0: [], 1: [] },
+      timeBuckets: [1533312112000]
+    };
+    assert.deepEqual(actual, expected, `Didn't call the expected method`);
+  });
+
+  it(`bucketed trades in categorical market`, () => {
+    const creationTimestamp = 1533312111000;
+    const currentTimestamp = 1533322111000;
+    const actual = selectBucketedPriceTimeSeries(
+      creationTimestamp,
+      currentTimestamp,
+      market2Outcomes
+    );
+    const expected = {
+      timeBuckets: [1533312111000, 1533315711000, 1533319311000],
+      priceTimeSeries: {
+        0: [
+          {
+            price: 0.1,
+            timestamp: 1533312111000
+          }
+        ],
+        1: [
+          {
+            price: 0.1,
+            timestamp: 1533312111000
+          }
+        ]
+      }
+    };
+    assert.deepEqual(actual, expected, `Didn't call the expected method`);
+  });
+
+  it(`bucketed trades in categorical market`, () => {
+    const creationTimestamp = 1533312111000;
+    const currentTimestamp = 1533322111000;
+    const actual = selectBucketedPriceTimeSeries(
+      creationTimestamp,
+      currentTimestamp,
+      market3Outcomes
+    );
+    const expected = {
+      timeBuckets: [1533312111000, 1533315711000, 1533319311000],
+      priceTimeSeries: {
+        0: [
+          {
+            price: 0.2,
+            timestamp: 1533315711000
+          },
+          {
+            price: 0.4,
+            timestamp: 1533319310004
+          }
+        ],
+        2: [
+          {
+            price: 0.2,
+            timestamp: 1533315711000
+          },
+          {
+            price: 0.4,
+            timestamp: 1533319310004
+          }
+        ]
+      }
+    };
+    assert.deepEqual(actual, expected, `Didn't call the expected method`);
+  });
+});

--- a/test/market/selectors/select-bucketed-price-series-test.js
+++ b/test/market/selectors/select-bucketed-price-series-test.js
@@ -103,7 +103,7 @@ describe(`modules/market/selectors/select-market-outcome-trading-indicator.js`, 
     );
     const expected = {
       priceTimeSeries: { 0: [], 1: [] },
-      timeBuckets: [1533312112000]
+      timeBuckets: [1533312112000, 1533312312000]
     };
     assert.deepEqual(actual, expected, `Didn't call the expected method`);
   });
@@ -117,7 +117,7 @@ describe(`modules/market/selectors/select-market-outcome-trading-indicator.js`, 
       market2Outcomes
     );
     const expected = {
-      timeBuckets: [1533312111000, 1533315711000, 1533319311000],
+      timeBuckets: [1533312111000, 1533315711000, 1533319311000, 1533322111000],
       priceTimeSeries: {
         0: [
           {
@@ -145,7 +145,7 @@ describe(`modules/market/selectors/select-market-outcome-trading-indicator.js`, 
       market3Outcomes
     );
     const expected = {
-      timeBuckets: [1533312111000, 1533315711000, 1533319311000],
+      timeBuckets: [1533312111000, 1533315711000, 1533319311000, 1533322111000],
       priceTimeSeries: {
         0: [
           {


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/10982/price-history-chart-should-show-average-price-over-time


you can use the script to populate categorical market
`./scripts/pop-candlesticks.sh 0x9a61edf382a0a482be8033f30612ff02c77ea8b2`

and manual create trades for other outcomes. notice the trade lines are smooth even though there has been many trades in the hour or in the day.


