### PR TITLE
johndanz/ch15716/liquidity-order-is-created-for-wrong-outcome

### DIFF
--- a/src/modules/create-market/actions/liquidity-management.js
+++ b/src/modules/create-market/actions/liquidity-management.js
@@ -51,6 +51,12 @@ export const startOrderSending = options => (dispatch, getState) => {
       )
     );
   }
+  // create a marketOutcomesArray which is an array of descriptions to match categorical outcomes to their proper index
+  const marketOutcomesArray = market.outcomes.reduce((acc, outcome) => {
+    acc.push(outcome.description);
+    return acc;
+  }, []);
+
   eachOfSeries(
     Object.keys(orderBook),
     (outcome, index, seriesCB) => {
@@ -62,7 +68,10 @@ export const startOrderSending = options => (dispatch, getState) => {
         orderBook[outcome],
         1,
         (order, orderId, orderCB) => {
-          const outcomeIndex = marketType === CATEGORICAL ? index : 1; // NOTE -- Both Scalar + Binary only trade against one outcome, that of outcomeId 1
+          const outcomeIndex =
+            marketType === CATEGORICAL
+              ? marketOutcomesArray.indexOf(outcome)
+              : 1; // NOTE -- Both Scalar + Binary only trade against one outcome, that of outcomeId 1
           const outcomeId = marketType === CATEGORICAL ? outcome : 1;
           const orderType = order.type === BID ? 0 : 1;
           const tradeCost = augur.trading.calculateTradeCost({

--- a/test/create-market/actions/liquidity-management-test.js
+++ b/test/create-market/actions/liquidity-management-test.js
@@ -26,7 +26,8 @@ describe(`modules/create-market/actions/liquidity-management.js`, () => {
         numTicks: "10000",
         marketType: YES_NO,
         minPrice: "0",
-        maxPrice: "1"
+        maxPrice: "1",
+        outcomes: [{ id: 0, description: null }, { id: 1, description: null }]
       }
     },
     pendingLiquidityOrders: {},


### PR DESCRIPTION
corrected an issue where categorical liquidity would place the orders on the wrong outcomes if you didn't have an order for every outcome or more specifically didn't have an order for the first outcome of a categorical market.

https://app.clubhouse.io/augur/story/15716/liquidity-order-is-created-for-wrong-outcome-when-creating-a-market