### PR TITLE
make market volume default sort

### DIFF
--- a/src/modules/filter-sort/reducers/sort-option.js
+++ b/src/modules/filter-sort/reducers/sort-option.js
@@ -1,8 +1,8 @@
 import { UPDATE_SORT_OPTION } from "modules/filter-sort/actions/update-sort-option";
 import { RESET_STATE } from "modules/app/actions/reset-state";
-import { MARKET_OPEN_INTEREST } from "modules/filter-sort/constants/market-sort-params";
+import { MARKET_VOLUME } from "modules/filter-sort/constants/market-sort-params";
 
-const DEFAULT_STATE = MARKET_OPEN_INTEREST;
+const DEFAULT_STATE = MARKET_VOLUME;
 
 export default function(sortOption = DEFAULT_STATE, action) {
   switch (action.type) {


### PR DESCRIPTION
convo in discord by Mr krug. I agree volume is more interesting.

```
Market default sort should be volume imo(edited)
Just noticed that got changed away to be recently traded
Makes it way harder to consolidate liquidity on open markets which is important for the success of this imo
Dunno how that got changed
```