### PR TITLE
don't cap resolution source urls

### DIFF
--- a/src/modules/market/components/market-properties/market-properties.styles.less
+++ b/src/modules/market/components/market-properties/market-properties.styles.less
@@ -60,7 +60,6 @@
     }
 
     > span {
-
       color: @color-purple;
       display: block;
 

--- a/src/modules/market/components/market-properties/market-properties.styles.less
+++ b/src/modules/market/components/market-properties/market-properties.styles.less
@@ -60,7 +60,6 @@
     }
 
     > span {
-      &:extend(.caps--medium);
 
       color: @color-purple;
       display: block;


### PR DESCRIPTION
upper casing can cause urls to not resolve when copying to web browsers.