### PR TITLE
fix labels when candlesticks longer than month in days

### DIFF
--- a/src/modules/market/constants/permissible-periods.js
+++ b/src/modules/market/constants/permissible-periods.js
@@ -28,7 +28,8 @@ export const RANGES = [
     duration: 604800,
     label: "Past week",
     isDefault: true,
-    tickInterval: axis => axis.ticks(timeDay.every(1))
+    tickInterval: axis =>
+      axis.ticks(timeDay.every(1)).tickFormat(timeFormat("%a %d"))
   },
   {
     duration: 2629800,


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/15795/dates-are-formatted-incorrectly-on-candlestick-chart

use pop-candlestick.sh script to add candlesticks and verify that dates on x axis are correct format
`Day of week # day of month` like Mon 4,