### PR TITLE
add next fee widnow rep stats to current fee window rep user stats, a…

### DIFF
--- a/src/modules/events/actions/log-handlers.js
+++ b/src/modules/events/actions/log-handlers.js
@@ -88,6 +88,7 @@ export const handleTokensTransferredLog = log => (dispatch, getState) => {
   if (isStoredTransaction) {
     dispatch(updateAssets());
     dispatch(loadFundingHistory());
+    dispatch(loadReportingWindowBounds());
     handleNotificationUpdate(log, dispatch, getState);
   }
 };

--- a/src/modules/reporting/actions/load-reporting-window-bounds.js
+++ b/src/modules/reporting/actions/load-reporting-window-bounds.js
@@ -1,5 +1,6 @@
 import { augur } from "services/augurjs";
 import logError from "utils/log-error";
+import { createBigNumber } from "utils/create-big-number";
 import { updateReportingWindowStats } from "modules/reporting/actions/update-reporting-window-stats";
 
 export const loadReportingWindowBounds = (callback = logError) => (
@@ -16,22 +17,55 @@ export const loadReportingWindowBounds = (callback = logError) => (
     (err, result) => {
       if (err) return callback(err);
 
-      dispatch(
-        updateReportingWindowStats({
-          startTime: (result || {}).startTime,
-          endTime: (result || {}).endTime,
-          stake: (result || {}).totalStake || 0,
-          participantContributions:
-            (result || {}).participantContributions || 0,
-          participationTokens: (result || {}).participationTokens || 0,
-          feeWindowRepStaked: (result || {}).feeWindowRepStaked || 0,
-          feeWindowEthFees: (result || {}).feeWindowEthFees || 0,
-          participantContributionsCrowdsourcer:
-            (result || {}).participantContributionsCrowdsourcer || 0,
-          participantContributionsInitialReport:
-            (result || {}).participantContributionsInitialReport || 0
-        })
+      augur.augurNode.submitRequest(
+        "getFeeWindow",
+        {
+          universe: universe.id,
+          reporter: loginAccount.address,
+          feeWindowState: "next"
+        },
+        (err, nextResult) => {
+          if (err) console.log(err); // just log error
+
+          dispatch(
+            updateReportingWindowStats({
+              startTime: (result || {}).startTime,
+              endTime: (result || {}).endTime,
+              stake: combineValues(
+                (result || {}).totalStake,
+                (nextResult || {}).totalStake
+              ),
+              participantContributions: combineValues(
+                (result || {}).participantContributions,
+                (nextResult || {}).participantContributions
+              ),
+              participationTokens: combineValues(
+                (result || {}).participationTokens,
+                (nextResult || {}).participationTokens
+              ),
+              feeWindowRepStaked: combineValues(
+                (result || {}).feeWindowRepStaked,
+                (nextResult || {}).feeWindowRepStaked
+              ),
+              feeWindowEthFees: (result || {}).feeWindowEthFees || 0,
+              participantContributionsCrowdsourcer: combineValues(
+                (result || {}).participantContributionsCrowdsourcer,
+                (nextResult || {}).participantContributionsCrowdsourcer
+              ),
+              participantContributionsInitialReport: combineValues(
+                (result || {}).participantContributionsInitialReport,
+                (nextResult || {}).participantContributionsInitialReport
+              )
+            })
+          );
+        }
       );
     }
   );
 };
+
+function combineValues(currentValue, nextValue) {
+  const current = createBigNumber(currentValue || 0);
+  const next = createBigNumber(nextValue || 0);
+  return current.plus(next).toString();
+}


### PR DESCRIPTION
…dded refresh fee window bounds when tokens are transferred, it's for participation tokens, mint log didn't come in

Need newest augur-node master

https://app.clubhouse.io/augur/story/15693/github-show-rep-on-next-fee-window


 to repro:

confirm that when user fills up dispute bond and market goes to next fee window that their REP shows up in the staked REP totals in dispute header page.