### PR TITLE
add user reported/disputed on markets to portfolio/reporting

### DIFF
--- a/src/modules/market/components/market-link/market-link.jsx
+++ b/src/modules/market/components/market-link/market-link.jsx
@@ -38,6 +38,14 @@ const MarketLink = p => {
       path = makePath(MARKET);
   }
 
+  const queryLink = {
+    [MARKET_ID_PARAM_NAME]: p.id
+  };
+
+  if (p.linkType === TYPE_DISPUTE) {
+    queryLink[RETURN_PARAM_NAME] = location.hash;
+  }
+
   return (
     <span>
       {p.id ? (
@@ -46,10 +54,7 @@ const MarketLink = p => {
           className={p.className}
           to={{
             pathname: path,
-            search: makeQuery({
-              [MARKET_ID_PARAM_NAME]: p.id,
-              [RETURN_PARAM_NAME]: location.hash
-            })
+            search: makeQuery(queryLink)
           }}
         >
           {p.children}

--- a/src/modules/market/components/market-link/market-link.jsx
+++ b/src/modules/market/components/market-link/market-link.jsx
@@ -16,7 +16,10 @@ import {
   DISPUTE,
   MIGRATE_REP
 } from "modules/routes/constants/views";
-import { MARKET_ID_PARAM_NAME } from "modules/routes/constants/param-names";
+import {
+  MARKET_ID_PARAM_NAME,
+  RETURN_PARAM_NAME
+} from "modules/routes/constants/param-names";
 
 const MarketLink = p => {
   let path;
@@ -44,7 +47,8 @@ const MarketLink = p => {
           to={{
             pathname: path,
             search: makeQuery({
-              [MARKET_ID_PARAM_NAME]: p.id
+              [MARKET_ID_PARAM_NAME]: p.id,
+              [RETURN_PARAM_NAME]: location.hash
             })
           }}
         >
@@ -60,7 +64,8 @@ const MarketLink = p => {
 MarketLink.propTypes = {
   id: PropTypes.string.isRequired,
   linkType: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  location: PropTypes.object
 };
 
 export default MarketLink;

--- a/src/modules/markets/components/markets-list.jsx
+++ b/src/modules/markets/components/markets-list.jsx
@@ -18,7 +18,7 @@ export default class MarketsList extends Component {
     filteredMarkets: PropTypes.array.isRequired,
     location: PropTypes.object.isRequired,
     toggleFavorite: PropTypes.func.isRequired,
-    loadMarketsInfoIfNotLoaded: PropTypes.func.isRequired,
+    loadMarketsInfoIfNotLoaded: PropTypes.func,
     paginationPageParam: PropTypes.string,
     linkType: PropTypes.string,
     showPagination: PropTypes.bool,
@@ -48,12 +48,14 @@ export default class MarketsList extends Component {
   }
 
   componentWillMount() {
-    const { filteredMarkets } = this.props;
-    this.loadMarketsInfoIfNotLoaded(filteredMarkets);
+    const { filteredMarkets, loadMarketsInfoIfNotLoaded } = this.props;
+    if (loadMarketsInfoIfNotLoaded) {
+      this.loadMarketsInfoIfNotLoaded(filteredMarkets);
+    }
   }
 
   componentWillUpdate(nextProps, nextState) {
-    const { filteredMarkets } = this.props;
+    const { filteredMarkets, loadMarketsInfoIfNotLoaded } = this.props;
     if (
       this.state.lowerBound !== nextState.lowerBound ||
       this.state.boundedLength !== nextState.boundedLength ||
@@ -68,8 +70,11 @@ export default class MarketsList extends Component {
 
     if (
       !isEqual(this.state.marketIdsMissingInfo, nextState.marketIdsMissingInfo)
-    )
-      this.loadMarketsInfoIfNotLoaded(nextState.marketIdsMissingInfo);
+    ) {
+      if (loadMarketsInfoIfNotLoaded) {
+        this.loadMarketsInfoIfNotLoaded(nextState.marketIdsMissingInfo);
+      }
+    }
   }
 
   setSegment(lowerBound, upperBound, boundedLength) {

--- a/src/modules/my-reports/actions/load-reporting-history.js
+++ b/src/modules/my-reports/actions/load-reporting-history.js
@@ -1,6 +1,8 @@
 import { augur } from "services/augurjs";
 import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets-info-if-not-loaded";
 import { addReportingTransactions } from "modules/transactions/actions/add-transactions";
+import { addMarketsReport } from "modules/reports/actions/update-reports";
+import { loadMarketsDisputeInfo } from "modules/markets/actions/load-markets-dispute-info";
 import logError from "utils/log-error";
 
 export const loadReportingHistory = (options = {}, callback = logError) => (
@@ -22,7 +24,10 @@ export const loadReportingHistory = (options = {}, callback = logError) => (
       dispatch(
         loadMarketsInfoIfNotLoaded(marketIds, err => {
           if (err) return callback(err);
+
+          dispatch(loadMarketsDisputeInfo(marketIds));
           dispatch(addReportingTransactions(reportingHistory));
+          dispatch(addMarketsReport(universe.id, marketIds));
           // TODO update user's reporting history
           callback(null, reportingHistory);
         })

--- a/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
+++ b/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
@@ -9,9 +9,25 @@ import {
 } from "modules/modal/constants/modal-types";
 import { TYPE_CLAIM_PROCEEDS } from "modules/market/constants/link-types";
 import Styles from "modules/portfolio/components/portfolio-reports/portfolio-reports.styles";
+import DisputingMarkets from "modules/reporting/components/common/disputing-markets";
+import ReportingResolved from "../../../reporting/components/reporting-resolved/reporting-resolved";
 
 export default class PortfolioReports extends Component {
   static propTypes = {
+    location: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired,
+    markets: PropTypes.array.isRequired,
+    upcomingMarkets: PropTypes.array.isRequired,
+    upcomingMarketsCount: PropTypes.number.isRequired,
+    isMobile: PropTypes.bool,
+    isConnected: PropTypes.bool.isRequired,
+    outcomes: PropTypes.object.isRequired,
+    isForking: PropTypes.bool.isRequired,
+    forkingMarketId: PropTypes.string.isRequired,
+    pageinationCount: PropTypes.number.isRequired,
+    disputableMarketsLength: PropTypes.number,
+    showPagination: PropTypes.bool,
+    showUpcomingPagination: PropTypes.bool,
     currentTimestamp: PropTypes.number.isRequired,
     getReportingFees: PropTypes.func.isRequired,
     isLogged: PropTypes.bool.isRequired,
@@ -19,7 +35,11 @@ export default class PortfolioReports extends Component {
     forkedMarket: PropTypes.object,
     getWinningBalances: PropTypes.func.isRequired,
     updateModal: PropTypes.func.isRequired,
-    reportingFees: PropTypes.object.isRequired
+    reportingFees: PropTypes.object.isRequired,
+    resolvedMarkets: PropTypes.array.isRequired,
+    toggleFavorite: PropTypes.func.isRequired,
+    loadMarketsInfoIfNotLoaded: PropTypes.func,
+    loadMarkets: PropTypes.func
   };
 
   constructor(props) {
@@ -72,7 +92,25 @@ export default class PortfolioReports extends Component {
       currentTimestamp,
       finalizeMarket,
       forkedMarket,
-      reportingFees
+      reportingFees,
+      history,
+      isForking,
+      isMobile,
+      location,
+      markets,
+      upcomingMarkets,
+      isConnected,
+      loadMarkets,
+      outcomes,
+      upcomingMarketsCount,
+      forkingMarketId,
+      pageinationCount,
+      disputableMarketsLength,
+      showPagination,
+      showUpcomingPagination,
+      loadMarketsInfoIfNotLoaded,
+      resolvedMarkets,
+      toggleFavorite
     } = this.props;
     let disableClaimReportingFeesNonforkedMarketsButton = "";
     if (
@@ -137,6 +175,36 @@ export default class PortfolioReports extends Component {
             />
           </section>
         )}
+        <div>
+          <DisputingMarkets
+            location={location}
+            history={history}
+            markets={markets}
+            upcomingMarkets={upcomingMarkets}
+            upcomingMarketsCount={upcomingMarketsCount}
+            isMobile={isMobile}
+            isConnected={isConnected}
+            loadMarkets={loadMarkets}
+            outcomes={outcomes}
+            isForking={isForking}
+            forkingMarketId={forkingMarketId}
+            pageinationCount={pageinationCount}
+            disputableMarketsLength={disputableMarketsLength}
+            showPagination={showPagination}
+            showUpcomingPagination={showUpcomingPagination}
+          />
+        </div>
+        <div className={Styles.PortfolioReports__resloved}>
+          <ReportingResolved
+            location={location}
+            history={history}
+            isLogged={isConnected}
+            loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
+            markets={resolvedMarkets}
+            noShowHeader
+            toggleFavorite={toggleFavorite}
+          />
+        </div>
       </div>
     );
   }

--- a/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
+++ b/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
@@ -10,7 +10,7 @@ import {
 import { TYPE_CLAIM_PROCEEDS } from "modules/market/constants/link-types";
 import Styles from "modules/portfolio/components/portfolio-reports/portfolio-reports.styles";
 import DisputingMarkets from "modules/reporting/components/common/disputing-markets";
-import ReportingResolved from "../../../reporting/components/reporting-resolved/reporting-resolved";
+import ReportingResolved from "modules/reporting/components/reporting-resolved/reporting-resolved";
 
 export default class PortfolioReports extends Component {
   static propTypes = {

--- a/src/modules/portfolio/components/portfolio-reports/portfolio-reports.styles.less
+++ b/src/modules/portfolio/components/portfolio-reports/portfolio-reports.styles.less
@@ -50,6 +50,10 @@ button.PortfolioReports__claim {
   padding: 0 2rem;
 }
 
+.PortfolioReports__resloved {
+  margin-top: 5rem;
+}
+
 @media @breakpoint-mobile {
   .PortfolioReports {
     padding: 0 1rem 1rem;

--- a/src/modules/portfolio/containers/reports.js
+++ b/src/modules/portfolio/containers/reports.js
@@ -1,22 +1,73 @@
+import { constants } from "services/augurjs";
 import { connect } from "react-redux";
 import { selectCurrentTimestamp } from "src/select-state";
-
+import { each, orderBy } from "lodash";
 import PortfolioReports from "modules/portfolio/components/portfolio-reports/portfolio-reports";
 import { updateModal } from "modules/modal/actions/update-modal";
 import { getReportingFees } from "modules/portfolio/actions/get-reporting-fees";
 import { getWinningBalance } from "modules/portfolio/actions/get-winning-balance";
 import { selectMarket } from "modules/market/selectors/market";
 import { sendFinalizeMarket } from "modules/market/actions/finalize-market";
+import marketDisputeOutcomes from "modules/reporting/selectors/select-market-dispute-outcomes";
+import { loadReportingHistory } from "modules/my-reports/actions/load-reporting-history";
+import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets-info-if-not-loaded";
+import { toggleFavorite } from "modules/markets/actions/update-favorites";
 
 const mapStateToProps = state => {
+  const PAGINATION_COUNT = 10;
   const forkedMarket = state.universe.isForking
     ? selectMarket(state.universe.forkingMarket)
     : null;
+  const disputeOutcomes = marketDisputeOutcomes() || {};
+  const disputableMarkets = [];
+  const upcomingDisputableMarkets = [];
+  const resolvedMarkets = [];
+
+  const reportedMarkets =
+    (state.reports &&
+      state.reports.markets &&
+      state.reports.markets[state.universe.id]) ||
+    [];
+
+  each(reportedMarkets, marketId => {
+    const market = selectMarket(marketId);
+    switch (market.reportingState) {
+      case constants.REPORTING_STATE.CROWDSOURCING_DISPUTE:
+        disputableMarkets.push(market);
+        break;
+      case constants.REPORTING_STATE.AWAITING_NEXT_WINDOW:
+        upcomingDisputableMarkets.push(market);
+        break;
+      case constants.REPORTING_STATE.AWAITING_FINALIZATION:
+      case constants.REPORTING_STATE.FINALIZED:
+        resolvedMarkets.push(market);
+        break;
+      default:
+        console.log("market not in reporting", marketId);
+    }
+  });
+
+  orderBy(resolvedMarkets, ["endTime.timestamp"], ["desc"]);
+
   return {
     currentTimestamp: selectCurrentTimestamp(state),
     forkedMarket,
     isLogged: state.isLogged,
-    reportingFees: state.reportingWindowStats.reportingFees
+    isMobile: state.isMobile,
+    isConnected: state.connection.isConnected && state.universe.id != null,
+    reportingFees: state.reportingWindowStats.reportingFees,
+    markets: disputableMarkets,
+    showPagination: disputableMarkets.length > PAGINATION_COUNT,
+    disputableMarketsLength: disputableMarkets.length,
+    upcomingMarkets: upcomingDisputableMarkets,
+    upcomingMarketsCount: upcomingDisputableMarkets.length,
+    showUpcomingPagination: upcomingDisputableMarkets.length > PAGINATION_COUNT,
+    pageinationCount: PAGINATION_COUNT,
+    outcomes: disputeOutcomes,
+    resolvedMarkets,
+    isForking: state.universe.isForking,
+    forkEndTime: state.universe.forkEndTime,
+    forkingMarketId: state.universe.forkingMarket
   };
 };
 
@@ -24,7 +75,11 @@ const mapDispatchToProps = dispatch => ({
   finalizeMarket: marketId => dispatch(sendFinalizeMarket(marketId)),
   getReportingFees: callback => dispatch(getReportingFees(callback)),
   getWinningBalances: marketIds => dispatch(getWinningBalance(marketIds)),
-  updateModal: modal => dispatch(updateModal(modal))
+  updateModal: modal => dispatch(updateModal(modal)),
+  loadMarkets: () => dispatch(loadReportingHistory()),
+  loadMarketsInfoIfNotLoaded: marketIds =>
+    dispatch(loadMarketsInfoIfNotLoaded(marketIds)),
+  toggleFavorite: marketId => dispatch(toggleFavorite(marketId))
 });
 
 export default connect(

--- a/src/modules/reporting/actions/submit-market-contribute.js
+++ b/src/modules/reporting/actions/submit-market-contribute.js
@@ -12,6 +12,7 @@ export const submitMarketContribute = (
   invalid,
   amount,
   history,
+  returnPath = REPORTING_DISPUTE_MARKETS,
   callback = logError
 ) => (dispatch, getState) => {
   const { loginAccount, marketsData } = getState();
@@ -35,7 +36,7 @@ export const submitMarketContribute = (
     _amount: amount,
     onSent: res => {
       if (!estimateGas) {
-        history.push(makePath(REPORTING_DISPUTE_MARKETS));
+        history.push(makePath(returnPath));
       }
     },
     onSuccess: gasCost => {

--- a/src/modules/reporting/components/common/disputing-markets.jsx
+++ b/src/modules/reporting/components/common/disputing-markets.jsx
@@ -1,0 +1,232 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import NullStateMessage from "modules/common/components/null-state-message/null-state-message";
+import DisputeMarketCard from "modules/reporting/components/dispute-market-card/dispute-market-card";
+import MarketsHeaderStyles from "modules/markets/components/markets-header/markets-header.styles";
+import Paginator from "modules/common/components/paginator/paginator";
+import isEqual from "lodash/isEqual";
+
+export default class DisputingMarkets extends Component {
+  static propTypes = {
+    location: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired,
+    markets: PropTypes.array.isRequired,
+    upcomingMarkets: PropTypes.array.isRequired,
+    upcomingMarketsCount: PropTypes.number.isRequired,
+    isMobile: PropTypes.bool,
+    isConnected: PropTypes.bool.isRequired,
+    outcomes: PropTypes.object.isRequired,
+    isForking: PropTypes.bool.isRequired,
+    forkingMarketId: PropTypes.string.isRequired,
+    pageinationCount: PropTypes.number.isRequired,
+    disputableMarketsLength: PropTypes.number,
+    showPagination: PropTypes.bool,
+    showUpcomingPagination: PropTypes.bool,
+    loadMarkets: PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      lowerBound: 1,
+      boundedLength: this.props.pageinationCount,
+      lowerBoundUpcoming: 1,
+      boundedLengthUpcoming: this.props.pageinationCount,
+      loadedMarkets: [],
+      filteredMarkets: [],
+      loadedUpcomingMarkets: [],
+      filteredUpcomingMarkets: []
+    };
+
+    this.setSegment = this.setSegment.bind(this);
+    this.setSegmentUpcoming = this.setSegmentUpcoming.bind(this);
+  }
+
+  componentWillMount() {
+    const { loadMarkets } = this.props;
+    if (loadMarkets) loadMarkets();
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    if (
+      this.state.lowerBound !== nextState.lowerBound ||
+      this.state.boundedLength !== nextState.boundedLength ||
+      !isEqual(this.state.loadedMarkets, nextProps.markets)
+    ) {
+      this.setLoadedMarkets(
+        nextProps.markets,
+        nextState.lowerBound,
+        nextState.boundedLength,
+        nextProps.showPagination
+      );
+    }
+    if (
+      this.state.lowerBoundUpcoming !== nextState.lowerBoundUpcoming ||
+      this.state.boundedLengthUpcoming !== nextState.boundedLengthUpcoming ||
+      !isEqual(this.state.loadedUpcomingMarkets, nextProps.upcomingMarkets)
+    ) {
+      this.setLoadedMarketsUpcoming(
+        nextProps.upcomingMarkets,
+        nextState.lowerBoundUpcoming,
+        nextState.boundedLengthUpcoming,
+        nextProps.showUpcomingPagination
+      );
+    }
+  }
+
+  setLoadedMarkets(markets, lowerBound, boundedLength, showPagination) {
+    const filteredMarkets =
+      this.filterMarkets(markets, lowerBound, boundedLength, showPagination) ||
+      [];
+    this.setState({ filteredMarkets, loadedMarkets: markets });
+  }
+
+  setLoadedMarketsUpcoming(markets, lowerBound, boundedLength, showPagination) {
+    const filteredUpcomingMarkets =
+      this.filterMarkets(markets, lowerBound, boundedLength, showPagination) ||
+      [];
+    this.setState({ filteredUpcomingMarkets, loadedUpcomingMarkets: markets });
+  }
+
+  setSegment(lowerBound, upperBound, boundedLength) {
+    this.setState({ lowerBound, boundedLength });
+  }
+
+  setSegmentUpcoming(lowerBoundUpcoming, upperBound, boundedLengthUpcoming) {
+    this.setState({ lowerBoundUpcoming, boundedLengthUpcoming });
+  }
+
+  filterMarkets(markets, lowerBound, boundedLength, showPagination) {
+    const { isConnected } = this.props;
+    if (isConnected) {
+      const marketIdLength = boundedLength + (lowerBound - 1);
+      const marketIds = markets.map(m => m.id);
+      const newMarketIdArray = marketIds.slice(lowerBound - 1, marketIdLength);
+
+      return showPagination
+        ? markets.filter(m => newMarketIdArray.indexOf(m.id) !== -1)
+        : markets;
+    }
+  }
+
+  render() {
+    const {
+      history,
+      isForking,
+      isMobile,
+      location,
+      markets,
+      outcomes,
+      upcomingMarketsCount,
+      forkingMarketId,
+      pageinationCount,
+      disputableMarketsLength,
+      showPagination,
+      showUpcomingPagination
+    } = this.props;
+    const { filteredMarkets, filteredUpcomingMarkets } = this.state;
+
+    let forkingMarket = null;
+    let nonForkingMarkets = filteredMarkets;
+    if (isForking) {
+      forkingMarket = markets.find(market => market.id === forkingMarketId);
+      nonForkingMarkets = filteredMarkets.filter(
+        market => market.id !== forkingMarketId
+      );
+    }
+    const nonForkingMarketsCount = filteredMarkets.length;
+
+    return (
+      <section>
+        {isForking && (
+          <DisputeMarketCard
+            key={forkingMarketId}
+            market={forkingMarket}
+            isMobile={isMobile}
+            location={location}
+            history={history}
+            outcomes={outcomes}
+            isForkingMarket
+          />
+        )}
+        {nonForkingMarketsCount > 0 &&
+          !isForking &&
+          nonForkingMarkets.map(market => (
+            <DisputeMarketCard
+              key={market.id}
+              market={market}
+              isMobile={isMobile}
+              location={location}
+              history={history}
+              outcomes={outcomes}
+              isForkingMarket={false}
+            />
+          ))}
+        {nonForkingMarketsCount > 0 &&
+          !isForking &&
+          showPagination && (
+            <Paginator
+              itemsLength={disputableMarketsLength}
+              itemsPerPage={pageinationCount}
+              location={location}
+              history={history}
+              setSegment={this.setSegment}
+              pageParam={"disputing" || null}
+            />
+          )}
+        {nonForkingMarketsCount === 0 &&
+          !isForking && (
+            <NullStateMessage message="There are currently no markets available for dispute." />
+          )}
+        <article className={MarketsHeaderStyles.MarketsHeader}>
+          <h4 className={MarketsHeaderStyles.MarketsHeader__subheading}>
+            {isForking ? "Dispute Paused" : "Upcoming Dispute Window"}
+          </h4>
+        </article>
+        {nonForkingMarketsCount > 0 &&
+          isForking &&
+          nonForkingMarkets.map(market => (
+            <DisputeMarketCard
+              key={market.id}
+              market={market}
+              isMobile={isMobile}
+              location={location}
+              history={history}
+              outcomes={outcomes}
+              isForkingMarket={false}
+            />
+          ))}
+        {upcomingMarketsCount > 0 &&
+          filteredUpcomingMarkets.map(market => (
+            <DisputeMarketCard
+              key={market.id}
+              market={market}
+              isMobile={isMobile}
+              location={location}
+              history={history}
+              outcomes={outcomes}
+            />
+          ))}
+        {upcomingMarketsCount > 0 &&
+          showUpcomingPagination && (
+            <Paginator
+              itemsLength={upcomingMarketsCount}
+              itemsPerPage={pageinationCount}
+              location={location}
+              history={history}
+              setSegment={this.setSegmentUpcoming}
+              pageParam={"upcoming" || null}
+            />
+          )}
+        {(upcomingMarketsCount === 0 ||
+          (nonForkingMarketsCount === 0 &&
+            upcomingMarketsCount === 0 &&
+            isForking)) && (
+          <NullStateMessage message="There are currently no markets slated for the upcoming dispute window." />
+        )}
+      </section>
+    );
+  }
+}

--- a/src/modules/reporting/components/dispute-market-card/dispute-market-card.jsx
+++ b/src/modules/reporting/components/dispute-market-card/dispute-market-card.jsx
@@ -88,7 +88,9 @@ const DisputeMarketCard = ({
           </div>
         </div>
         <h1 className={CommonStyles.MarketCommon__description}>
-          <MarketLink id={market.id}>{market.description}</MarketLink>
+          <MarketLink id={market.id} location={location}>
+            {market.description}
+          </MarketLink>
         </h1>
         {isForkingMarket && <ForkMigrationTotals />}
         {!isForkingMarket && (

--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
@@ -4,11 +4,7 @@ import PropTypes from "prop-types";
 
 import ReportingHeader from "modules/reporting/containers/reporting-header";
 import ReportDisputeNoRepState from "src/modules/reporting/components/reporting-dispute-no-rep-state/reporting-dispute-no-rep-state";
-import NullStateMessage from "modules/common/components/null-state-message/null-state-message";
-import DisputeMarketCard from "modules/reporting/components/dispute-market-card/dispute-market-card";
-import MarketsHeaderStyles from "modules/markets/components/markets-header/markets-header.styles";
-import Paginator from "modules/common/components/paginator/paginator";
-import isEqual from "lodash/isEqual";
+import DisputingMarkets from "modules/reporting/components/common/disputing-markets";
 
 const Styles = require("./reporting-dispute-markets.styles");
 
@@ -34,89 +30,9 @@ export default class ReportingDisputeMarkets extends Component {
     showUpcomingPagination: PropTypes.bool
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      lowerBound: 1,
-      boundedLength: this.props.pageinationCount,
-      lowerBoundUpcoming: 1,
-      boundedLengthUpcoming: this.props.pageinationCount,
-      loadedMarkets: [],
-      filteredMarkets: [],
-      loadedUpcomingMarkets: [],
-      filteredUpcomingMarkets: []
-    };
-
-    this.setSegment = this.setSegment.bind(this);
-    this.setSegmentUpcoming = this.setSegmentUpcoming.bind(this);
-  }
-
   componentWillMount() {
     const { loadMarkets } = this.props;
     loadMarkets();
-  }
-
-  componentWillUpdate(nextProps, nextState) {
-    if (
-      this.state.lowerBound !== nextState.lowerBound ||
-      this.state.boundedLength !== nextState.boundedLength ||
-      !isEqual(this.state.loadedMarkets, nextProps.markets)
-    ) {
-      this.setLoadedMarkets(
-        nextProps.markets,
-        nextState.lowerBound,
-        nextState.boundedLength,
-        nextProps.showPagination
-      );
-    }
-    if (
-      this.state.lowerBoundUpcoming !== nextState.lowerBoundUpcoming ||
-      this.state.boundedLengthUpcoming !== nextState.boundedLengthUpcoming ||
-      !isEqual(this.state.loadedUpcomingMarkets, nextProps.upcomingMarkets)
-    ) {
-      this.setLoadedMarketsUpcoming(
-        nextProps.upcomingMarkets,
-        nextState.lowerBoundUpcoming,
-        nextState.boundedLengthUpcoming,
-        nextProps.showUpcomingPagination
-      );
-    }
-  }
-
-  setLoadedMarkets(markets, lowerBound, boundedLength, showPagination) {
-    const filteredMarkets =
-      this.filterMarkets(markets, lowerBound, boundedLength, showPagination) ||
-      [];
-    this.setState({ filteredMarkets, loadedMarkets: markets });
-  }
-
-  setLoadedMarketsUpcoming(markets, lowerBound, boundedLength, showPagination) {
-    const filteredUpcomingMarkets =
-      this.filterMarkets(markets, lowerBound, boundedLength, showPagination) ||
-      [];
-    this.setState({ filteredUpcomingMarkets, loadedUpcomingMarkets: markets });
-  }
-
-  setSegment(lowerBound, upperBound, boundedLength) {
-    this.setState({ lowerBound, boundedLength });
-  }
-
-  setSegmentUpcoming(lowerBoundUpcoming, upperBound, boundedLengthUpcoming) {
-    this.setState({ lowerBoundUpcoming, boundedLengthUpcoming });
-  }
-
-  filterMarkets(markets, lowerBound, boundedLength, showPagination) {
-    const { isConnected } = this.props;
-    if (isConnected) {
-      const marketIdLength = boundedLength + (lowerBound - 1);
-      const marketIds = markets.map(m => m.id);
-      const newMarketIdArray = marketIds.slice(lowerBound - 1, marketIdLength);
-
-      return showPagination
-        ? markets.filter(m => newMarketIdArray.indexOf(m.id) !== -1)
-        : markets;
-    }
   }
 
   render() {
@@ -129,6 +45,9 @@ export default class ReportingDisputeMarkets extends Component {
       location,
       markets,
       navigateToAccountDepositHandler,
+      upcomingMarkets,
+      isConnected,
+      loadMarkets,
       outcomes,
       upcomingMarketsCount,
       forkingMarketId,
@@ -137,17 +56,6 @@ export default class ReportingDisputeMarkets extends Component {
       showPagination,
       showUpcomingPagination
     } = this.props;
-    const { filteredMarkets, filteredUpcomingMarkets } = this.state;
-
-    let forkingMarket = null;
-    let nonForkingMarkets = filteredMarkets;
-    if (isForking) {
-      forkingMarket = markets.find(market => market.id === forkingMarketId);
-      nonForkingMarkets = filteredMarkets.filter(
-        market => market.id !== forkingMarketId
-      );
-    }
-    const nonForkingMarketsCount = filteredMarkets.length;
 
     return (
       <section className={Styles.ReportDisputeContainer}>
@@ -169,92 +77,23 @@ export default class ReportingDisputeMarkets extends Component {
               />
             )}
         </section>
-        {isForking && (
-          <DisputeMarketCard
-            key={forkingMarketId}
-            market={forkingMarket}
-            isMobile={isMobile}
-            location={location}
-            history={history}
-            outcomes={outcomes}
-            isForkingMarket
-          />
-        )}
-        {nonForkingMarketsCount > 0 &&
-          !isForking &&
-          nonForkingMarkets.map(market => (
-            <DisputeMarketCard
-              key={market.id}
-              market={market}
-              isMobile={isMobile}
-              location={location}
-              history={history}
-              outcomes={outcomes}
-              isForkingMarket={false}
-            />
-          ))}
-        {nonForkingMarketsCount > 0 &&
-          !isForking &&
-          showPagination && (
-            <Paginator
-              itemsLength={disputableMarketsLength}
-              itemsPerPage={pageinationCount}
-              location={location}
-              history={history}
-              setSegment={this.setSegment}
-              pageParam={"disputing" || null}
-            />
-          )}
-        {nonForkingMarketsCount === 0 &&
-          !isForking && (
-            <NullStateMessage message="There are currently no markets available for dispute." />
-          )}
-        <article className={MarketsHeaderStyles.MarketsHeader}>
-          <h4 className={MarketsHeaderStyles.MarketsHeader__subheading}>
-            {isForking ? "Dispute Paused" : "Upcoming Dispute Window"}
-          </h4>
-        </article>
-        {nonForkingMarketsCount > 0 &&
-          isForking &&
-          nonForkingMarkets.map(market => (
-            <DisputeMarketCard
-              key={market.id}
-              market={market}
-              isMobile={isMobile}
-              location={location}
-              history={history}
-              outcomes={outcomes}
-              isForkingMarket={false}
-            />
-          ))}
-        {upcomingMarketsCount > 0 &&
-          filteredUpcomingMarkets.map(market => (
-            <DisputeMarketCard
-              key={market.id}
-              market={market}
-              isMobile={isMobile}
-              location={location}
-              history={history}
-              outcomes={outcomes}
-            />
-          ))}
-        {upcomingMarketsCount > 0 &&
-          showUpcomingPagination && (
-            <Paginator
-              itemsLength={upcomingMarketsCount}
-              itemsPerPage={pageinationCount}
-              location={location}
-              history={history}
-              setSegment={this.setSegmentUpcoming}
-              pageParam={"upcoming" || null}
-            />
-          )}
-        {(upcomingMarketsCount === 0 ||
-          (nonForkingMarketsCount === 0 &&
-            upcomingMarketsCount === 0 &&
-            isForking)) && (
-          <NullStateMessage message="There are currently no markets slated for the upcoming dispute window." />
-        )}
+        <DisputingMarkets
+          location={location}
+          history={history}
+          markets={markets}
+          upcomingMarkets={upcomingMarkets}
+          upcomingMarketsCount={upcomingMarketsCount}
+          isMobile={isMobile}
+          isConnected={isConnected}
+          loadMarkets={loadMarkets}
+          outcomes={outcomes}
+          isForking={isForking}
+          forkingMarketId={forkingMarketId}
+          pageinationCount={pageinationCount}
+          disputableMarketsLength={disputableMarketsLength}
+          showPagination={showPagination}
+          showUpcomingPagination={showUpcomingPagination}
+        />
       </section>
     );
   }

--- a/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
+++ b/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
@@ -24,12 +24,13 @@ export default class ReportingResolved extends Component {
     history: PropTypes.object,
     isLogged: PropTypes.bool,
     loadMarketsInfoIfNotLoaded: PropTypes.func,
-    loadReporting: PropTypes.func.isRequired,
     location: PropTypes.object,
     markets: PropTypes.array.isRequired,
     toggleFavorite: PropTypes.func,
     isForkingMarketFinalized: PropTypes.bool,
-    forkingMarket: PropTypes.object
+    noShowHeader: PropTypes.bool,
+    forkingMarket: PropTypes.object,
+    loadReporting: PropTypes.func
   };
 
   constructor(props) {
@@ -42,7 +43,7 @@ export default class ReportingResolved extends Component {
 
   componentWillMount() {
     const { loadReporting } = this.props;
-    loadReporting();
+    if (loadReporting) loadReporting();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -62,7 +63,8 @@ export default class ReportingResolved extends Component {
       markets,
       toggleFavorite,
       isForkingMarketFinalized,
-      forkingMarket
+      forkingMarket,
+      noShowHeader
     } = this.props;
     const s = this.state;
 
@@ -71,7 +73,7 @@ export default class ReportingResolved extends Component {
         <Helmet>
           <title>Resolved</title>
         </Helmet>
-        <ReportingHeader heading="Resolved" />
+        {!noShowHeader && <ReportingHeader heading="Resolved" />}
         {isForkingMarketFinalized && (
           <div className={Styles["ReportingResolved__forked-market-card"]}>
             <h2 className={Styles.ReportingResolved__heading}>Forked Market</h2>

--- a/src/modules/reporting/components/reporting-resolved/reporting-resolved.styles.less
+++ b/src/modules/reporting/components/reporting-resolved/reporting-resolved.styles.less
@@ -6,7 +6,7 @@
   font-weight: 500;
   letter-spacing: 0.3px;
   line-height: @font-size-large;
-  padding: 0 2rem 1rem;
+  padding: 0 2rem;
   text-transform: uppercase;
 
   @media @breakpoint-mobile {

--- a/src/modules/reporting/components/reporting-resolved/reporting-resolved.styles.less
+++ b/src/modules/reporting/components/reporting-resolved/reporting-resolved.styles.less
@@ -6,7 +6,7 @@
   font-weight: 500;
   letter-spacing: 0.3px;
   line-height: @font-size-large;
-  padding: 0 2rem;
+  padding: 0.25rem 2rem;
   text-transform: uppercase;
 
   @media @breakpoint-mobile {

--- a/src/modules/reporting/containers/reporting-dispute.js
+++ b/src/modules/reporting/containers/reporting-dispute.js
@@ -7,7 +7,10 @@ import {
   MARKET_ID_PARAM_NAME,
   RETURN_PARAM_NAME
 } from "modules/routes/constants/param-names";
-import { PORTFOLIO_REPORTS, REPORTING_DISPUTE_MARKETS } from "modules/routes/constants/views";
+import {
+  PORTFOLIO_REPORTS,
+  REPORTING_DISPUTE_MARKETS
+} from "modules/routes/constants/views";
 import { selectMarket } from "modules/market/selectors/market";
 import parseQuery from "modules/routes/helpers/parse-query";
 import getValue from "utils/get-value";

--- a/src/modules/reporting/containers/reporting-dispute.js
+++ b/src/modules/reporting/containers/reporting-dispute.js
@@ -3,7 +3,11 @@ import { withRouter } from "react-router-dom";
 
 import ReportingDispute from "modules/reporting/components/reporting-dispute/reporting-dispute";
 import { loadFullMarket } from "modules/market/actions/load-full-market";
-import { MARKET_ID_PARAM_NAME } from "modules/routes/constants/param-names";
+import {
+  MARKET_ID_PARAM_NAME,
+  RETURN_PARAM_NAME
+} from "modules/routes/constants/param-names";
+import { PORTFOLIO_REPORTS, REPORTING_DISPUTE_MARKETS } from "modules/routes/constants/views";
 import { selectMarket } from "modules/market/selectors/market";
 import parseQuery from "modules/routes/helpers/parse-query";
 import getValue from "utils/get-value";
@@ -46,7 +50,13 @@ const mapDispatchToProps = dispatch => ({
 
 const mergeProps = (sP, dP, oP) => {
   const marketId = parseQuery(oP.location.search)[MARKET_ID_PARAM_NAME];
+  const returnPath = parseQuery(oP.location.search)[RETURN_PARAM_NAME];
   const market = selectMarket(marketId);
+
+  let redirectPath = REPORTING_DISPUTE_MARKETS;
+  if (returnPath.indexOf(PORTFOLIO_REPORTS) !== -1) {
+    redirectPath = PORTFOLIO_REPORTS;
+  }
 
   return {
     ...oP,
@@ -73,6 +83,7 @@ const mergeProps = (sP, dP, oP) => {
         invalid,
         amount,
         history,
+        redirectPath,
         callback
       )
   };

--- a/src/modules/reports/actions/update-reports.js
+++ b/src/modules/reports/actions/update-reports.js
@@ -1,5 +1,6 @@
 export const UPDATE_REPORTS = "UPDATE_REPORTS";
 export const UPDATE_REPORT = "UPDATE_REPORT";
+export const MARKETS_REPORT = "MARKETS_REPORT";
 
 export const updateReports = reports => ({ type: UPDATE_REPORTS, reports });
 export const updateReport = (universeId, marketId, report) => ({
@@ -7,4 +8,10 @@ export const updateReport = (universeId, marketId, report) => ({
   universeId,
   marketId,
   report
+});
+
+export const addMarketsReport = (universeId, marketIds) => ({
+  type: MARKETS_REPORT,
+  universeId,
+  marketIds
 });

--- a/src/modules/reports/reducers/reports.js
+++ b/src/modules/reports/reducers/reports.js
@@ -11,6 +11,7 @@ export default function(reports = DEFAULT_STATE, action) {
   switch (action.type) {
     case UPDATE_REPORTS: {
       const updatedReports = { ...reports };
+      if (!action || !action.reports) return updatedReports;
       const universeIds = Object.keys(action.reports);
       const numUniverseIds = universeIds.length;
       for (let i = 0; i < numUniverseIds; ++i) {

--- a/src/modules/reports/reducers/reports.js
+++ b/src/modules/reports/reducers/reports.js
@@ -1,6 +1,7 @@
 import {
   UPDATE_REPORTS,
-  UPDATE_REPORT
+  UPDATE_REPORT,
+  MARKETS_REPORT
 } from "modules/reports/actions/update-reports";
 import { RESET_STATE } from "modules/app/actions/reset-state";
 
@@ -35,6 +36,13 @@ export default function(reports = DEFAULT_STATE, action) {
         }
       };
     }
+    case MARKETS_REPORT:
+      return {
+        ...reports,
+        markets: {
+          [action.universeId]: action.marketIds
+        }
+      };
     case RESET_STATE:
       return DEFAULT_STATE;
     default:

--- a/src/modules/reports/reducers/reports.js
+++ b/src/modules/reports/reducers/reports.js
@@ -19,6 +19,7 @@ export default function(reports = DEFAULT_STATE, action) {
           ...reports[universeIds[i]],
           ...action.reports[universeIds[i]]
         };
+        updatedReports.markets = [];
       }
       return updatedReports;
     }

--- a/src/modules/routes/constants/param-names.js
+++ b/src/modules/routes/constants/param-names.js
@@ -8,4 +8,5 @@ export const CREATE_NAV = "create-nav";
 // Unorg'd
 export const SUBSET_PARAM_NAME = "subset";
 export const MARKET_ID_PARAM_NAME = "id";
+export const RETURN_PARAM_NAME = "return";
 export const MODAL_PARAM_NAME = "modal";

--- a/test/reporting/actions/submit-market-contribute-test.js
+++ b/test/reporting/actions/submit-market-contribute-test.js
@@ -1,6 +1,7 @@
 import sinon from "sinon";
 import testState from "test/testState";
 import configureMockStore from "redux-mock-store";
+import { REPORTING_DISPUTE_MARKETS } from "modules/routes/constants/views";
 import thunk from "redux-thunk";
 import {
   submitMarketContribute,
@@ -72,6 +73,7 @@ describe(`modules/reporting/actions/submit-market-contribute.js`, () => {
         false,
         1000,
         history,
+        REPORTING_DISPUTE_MARKETS,
         callback
       )
     );
@@ -89,6 +91,7 @@ describe(`modules/reporting/actions/submit-market-contribute.js`, () => {
         false,
         1000,
         history,
+        REPORTING_DISPUTE_MARKETS,
         callback
       )
     );
@@ -99,7 +102,16 @@ describe(`modules/reporting/actions/submit-market-contribute.js`, () => {
   it(`should only call callback with null market id`, () => {
     submitMarketContributeReqireAPI.__Rewire__("augur", augurSuccess);
     store.dispatch(
-      submitMarketContribute(false, null, 0, false, 1000, history, callback)
+      submitMarketContribute(
+        false,
+        null,
+        0,
+        false,
+        1000,
+        history,
+        REPORTING_DISPUTE_MARKETS,
+        callback
+      )
     );
     assert(callback.calledOnce, `Didn't call 'callback' once as expected`);
     assert(history.push.notCalled, `Did call 'history' not expected`);
@@ -108,7 +120,16 @@ describe(`modules/reporting/actions/submit-market-contribute.js`, () => {
   it(`should only callback with empty market id`, () => {
     submitMarketContributeReqireAPI.__Rewire__("augur", augurSuccess);
     store.dispatch(
-      submitMarketContribute(false, "", 0, false, 1000, history, callback)
+      submitMarketContribute(
+        false,
+        "",
+        0,
+        false,
+        1000,
+        history,
+        REPORTING_DISPUTE_MARKETS,
+        callback
+      )
     );
     assert(callback.calledOnce, `Didn't call 'callback' once as expected`);
     assert(history.push.notCalled, `Did call 'history' not expected`);
@@ -124,6 +145,7 @@ describe(`modules/reporting/actions/submit-market-contribute.js`, () => {
         false,
         1000,
         history,
+        REPORTING_DISPUTE_MARKETS,
         callback
       )
     );
@@ -141,6 +163,7 @@ describe(`modules/reporting/actions/submit-market-contribute.js`, () => {
         false,
         1000,
         history,
+        REPORTING_DISPUTE_MARKETS,
         callback
       )
     );
@@ -158,6 +181,7 @@ describe(`modules/reporting/actions/submit-market-contribute.js`, () => {
         false,
         1000,
         history,
+        REPORTING_DISPUTE_MARKETS,
         callback
       )
     );

--- a/test/reports/reducers/reports-test.js
+++ b/test/reports/reducers/reports-test.js
@@ -59,7 +59,8 @@ describe(`modules/reports/reducers/reports.js`, () => {
               isSubmitted: false,
               isIndeterminate: false
             }
-          }
+          },
+          markets: []
         },
         `Didn't update report information`
       );

--- a/test/transactions/actions/trigger-transactions-export-test.js
+++ b/test/transactions/actions/trigger-transactions-export-test.js
@@ -1,6 +1,10 @@
 import proxyquire from "proxyquire";
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
+import {
+  triggerTransactionsExport,
+  __RewireAPI__ as RewireReExport
+} from "modules/transactions/actions/trigger-transactions-export";
 
 describe(`modules/transactions/actions/trigger-transactions-export.js`, () => {
   proxyquire.noPreserveCache().noCallThru();
@@ -11,20 +15,18 @@ describe(`modules/transactions/actions/trigger-transactions-export.js`, () => {
   const test = t => {
     it(t.description, () => {
       const store = mockStore(t.state);
-      const action = proxyquire(
-        "../../../src/modules/transactions/actions/trigger-transactions-export",
-        {
-          "../selectors/transactions": t.transactionsSelector,
-          "../../auth/actions/load-account-history": t.loadAccountHistory
-        }
-      );
+      RewireReExport.__Rewire__("selectTransactions", t.selectTransactions);
+      RewireReExport.__Rewire__("loadAccountHistory", t.loadAccountHistory);
 
       global.document = t.document;
 
-      store.dispatch(action.triggerTransactionsExport());
+      store.dispatch(triggerTransactionsExport());
       t.assertions(store.getActions(), t.expectedOutput);
 
       global.document = doc;
+
+      RewireReExport.__ResetDependency__("selectTransactions");
+      RewireReExport.__ResetDependency__("loadAccountHistory");
     });
   };
   test({
@@ -36,15 +38,11 @@ describe(`modules/transactions/actions/trigger-transactions-export.js`, () => {
       ],
       transactionsLoading: false
     },
-    transactionsSelector: {
-      selectTransactions: state => state.transactions
-    },
-    loadAccountHistory: {
-      loadAccountHistory: (loadAll, cb) => ({
-        type: "LOAD_ACCOUNT_HISTORY",
-        loadAll
-      })
-    },
+    selectTransactions: state => state.transactions,
+    loadAccountHistory: (loadAll, cb) => ({
+      type: "LOAD_ACCOUNT_HISTORY",
+      loadAll
+    }),
     document: {
       createElement: type => {
         assert.equal(type, "a");
@@ -98,18 +96,16 @@ describe(`modules/transactions/actions/trigger-transactions-export.js`, () => {
     transactionsSelector: {
       selectTransactions: state => state.transactions
     },
-    loadAccountHistory: {
-      loadAccountHistory: (loadAll, cb) => {
-        assert.isTrue(
-          loadAll,
-          "loadAll passed to loadAccountHistory should be true"
-        );
-        assert.isFunction(
-          cb,
-          "cb passed to loadAccountHistory should be a function"
-        );
-        return { type: "LOAD_ACCOUNT_HISTORY", loadAll };
-      }
+    loadAccountHistory: (loadAll, cb) => {
+      assert.isTrue(
+        loadAll,
+        "loadAll passed to loadAccountHistory should be true"
+      );
+      assert.isFunction(
+        cb,
+        "cb passed to loadAccountHistory should be a function"
+      );
+      return { type: "LOAD_ACCOUNT_HISTORY", loadAll };
     },
     expectedOutput: [{ type: "LOAD_ACCOUNT_HISTORY", loadAll: true }],
     assertions: (storeActions, expected) => {


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/15220/add-list-of-user-s-disputed-and-resolved-markets-to-portfolio-reporting-page

report on markets and verify the user reported/disputed markets show up in portfolio -> reporting.

currently an issue where user clicks to dispute on market then finishes dispute and gets redirected to Reporting dispute page, but Portfolio section is selected. 