### PR TITLE
phoebemirman/ch7966/market-card-additional-details-should-slide

### DIFF
--- a/src/modules/forking/components/migrate-rep/migrate-rep.jsx
+++ b/src/modules/forking/components/migrate-rep/migrate-rep.jsx
@@ -11,7 +11,6 @@ import NullStateMessage from "modules/common/components/null-state-message/null-
 import MigrateRepForm from "modules/forking/components/migrate-rep-form/migrate-rep-form";
 import MigrateRepConfirm from "modules/forking/components/migrate-rep-confirm/migrate-rep-confirm";
 import { TYPE_VIEW } from "modules/markets/constants/link-types";
-import MarketAdditonalDetails from "modules/reporting/components/market-additional-details/market-additional-details";
 import { isEmpty } from "lodash";
 import FormStyles from "modules/common/less/form";
 import Styles from "modules/reporting/components/reporting-report/reporting-report.styles";
@@ -37,7 +36,6 @@ export default class MigrateRep extends Component {
 
     this.state = {
       currentStep: 0,
-      showingDetails: true,
       isMarketInValid: null,
       selectedOutcome: "",
       selectedOutcomeName: "",
@@ -53,7 +51,6 @@ export default class MigrateRep extends Component {
     this.prevPage = this.prevPage.bind(this);
     this.nextPage = this.nextPage.bind(this);
     this.updateState = this.updateState.bind(this);
-    this.toggleDetails = this.toggleDetails.bind(this);
   }
 
   componentWillMount() {
@@ -79,10 +76,6 @@ export default class MigrateRep extends Component {
 
   updateState(newState) {
     this.setState(newState);
-  }
-
-  toggleDetails() {
-    this.setState({ showingDetails: !this.state.showingDetails });
   }
 
   calculateGasEstimates() {
@@ -140,12 +133,8 @@ export default class MigrateRep extends Component {
             linkType={TYPE_VIEW}
             buttonText="View"
             showAdditionalDetailsToggle
-            showingDetails={s.showingDetails}
-            toggleDetails={this.toggleDetails}
           />
         )}
-        {!isEmpty(market) &&
-          s.showingDetails && <MarketAdditonalDetails market={market} />}
         {!isEmpty(market) && (
           <article className={FormStyles.Form}>
             {s.currentStep === 0 && (

--- a/src/modules/market/components/market-preview/market-preview.jsx
+++ b/src/modules/market/components/market-preview/market-preview.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
@@ -6,68 +6,113 @@ import MarketBasics from "modules/market/containers/market-basics";
 import MarketProperties from "modules/market/containers/market-properties";
 import OutstandingReturns from "modules/market/components/market-outstanding-returns/market-outstanding-returns";
 import MarketLiquidity from "modules/market/containers/market-liquidity";
+import toggleHeight from "utils/toggle-height/toggle-height";
 
 import CommonStyles from "modules/market/components/common/market-common.styles";
 import Styles from "modules/market/components/market-preview/market-preview.styles";
+import MarketAdditonalDetails from "modules/reporting/components/market-additional-details/market-additional-details";
+import { isEmpty } from "lodash";
+import ToggleHeightStyles from "utils/toggle-height/toggle-height.styles";
 
-const MarketPreview = p => (
-  <article
-    className={classNames(CommonStyles.MarketCommon__container, {
-      [`${CommonStyles["single-card"]}`]: p.cardStyle === "single-card"
-    })}
-    id={"id-" + p.id}
-    data-testid={p.testid + "-" + p.id}
-  >
-    <MarketBasics {...p} />
-    <div
-      className={classNames(Styles.MarketPreview__footer, {
-        [`${Styles["single-card"]}`]: p.cardStyle === "single-card"
-      })}
-    >
-      <MarketProperties {...p} />
-    </div>
-    {p.unclaimedCreatorFees.value > 0 &&
-      p.collectMarketCreatorFees && (
-        <div
-          className={classNames(Styles.MarketPreview__returns, {
-            [`${Styles["single-card"]}`]: p.cardStyle === "single-card"
+export default class MarketPreview extends Component {
+  static propTypes = {
+    testid: PropTypes.string,
+    id: PropTypes.string,
+    isLogged: PropTypes.bool.isRequired,
+    toggleFavorite: PropTypes.func,
+    className: PropTypes.string,
+    description: PropTypes.string,
+    outcomes: PropTypes.array,
+    isOpen: PropTypes.bool,
+    isFavorite: PropTypes.bool,
+    isPendingReport: PropTypes.bool,
+    endTime: PropTypes.object,
+    settlementFeePercent: PropTypes.object,
+    volume: PropTypes.object,
+    tags: PropTypes.array,
+    onClickToggleFavorite: PropTypes.func,
+    cardStyle: PropTypes.string,
+    hideReportEndingIndicator: PropTypes.bool,
+    linkType: PropTypes.string,
+    collectMarketCreatorFees: PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showingDetails: true
+    };
+
+    this.toggleDetails = this.toggleDetails.bind(this);
+  }
+
+  toggleDetails() {
+    toggleHeight(this.additionalDetails, this.state.showingDetails, () => {
+      this.setState({ showingDetails: !this.state.showingDetails });
+    });
+  }
+
+  render() {
+    const p = this.props;
+    const s = this.state;
+
+    return (
+      <div>
+        <article
+          className={classNames(CommonStyles.MarketCommon__container, {
+            [`${CommonStyles["single-card"]}`]: p.cardStyle === "single-card"
           })}
+          id={"id-" + p.id}
+          data-testid={p.testid + "-" + p.id}
         >
-          <OutstandingReturns
-            id={p.id}
-            unclaimedCreatorFees={p.unclaimedCreatorFees}
-            collectMarketCreatorFees={p.collectMarketCreatorFees}
+          <MarketBasics {...p} />
+          <div
+            className={classNames(Styles.MarketPreview__footer, {
+              [`${Styles["single-card"]}`]: p.cardStyle === "single-card"
+            })}
+          >
+            <MarketProperties
+              {...p}
+              showingDetails={s.showingDetails}
+              toggleDetails={this.toggleDetails}
+            />
+          </div>
+          {p.unclaimedCreatorFees.value > 0 &&
+            p.collectMarketCreatorFees && (
+              <div
+                className={classNames(Styles.MarketPreview__returns, {
+                  [`${Styles["single-card"]}`]: p.cardStyle === "single-card"
+                })}
+              >
+                <OutstandingReturns
+                  id={p.id}
+                  unclaimedCreatorFees={p.unclaimedCreatorFees}
+                  collectMarketCreatorFees={p.collectMarketCreatorFees}
+                />
+              </div>
+            )}
+          <MarketLiquidity
+            marketId={p.id}
+            market={p}
+            pendingLiquidityOrders={p.pendingLiquidityOrders}
           />
-        </div>
-      )}
-    <MarketLiquidity
-      marketId={p.id}
-      market={p}
-      pendingLiquidityOrders={p.pendingLiquidityOrders}
-    />
-  </article>
-);
-
-MarketPreview.propTypes = {
-  testid: PropTypes.string,
-  id: PropTypes.string,
-  isLogged: PropTypes.bool.isRequired,
-  toggleFavorite: PropTypes.func,
-  className: PropTypes.string,
-  description: PropTypes.string,
-  outcomes: PropTypes.array,
-  isOpen: PropTypes.bool,
-  isFavorite: PropTypes.bool,
-  isPendingReport: PropTypes.bool,
-  endTime: PropTypes.object,
-  settlementFeePercent: PropTypes.object,
-  volume: PropTypes.object,
-  tags: PropTypes.array,
-  onClickToggleFavorite: PropTypes.func,
-  cardStyle: PropTypes.string,
-  hideReportEndingIndicator: PropTypes.bool,
-  linkType: PropTypes.string,
-  collectMarketCreatorFees: PropTypes.func
-};
-
-export default MarketPreview;
+        </article>
+        {!isEmpty(p) &&
+          p.showAdditionalDetailsToggle && (
+            <div
+              ref={additionalDetails => {
+                this.additionalDetails = additionalDetails;
+              }}
+              className={classNames(
+                ToggleHeightStyles["toggle-height-target"],
+                ToggleHeightStyles["start-open"]
+              )}
+            >
+              <MarketAdditonalDetails market={p} />
+            </div>
+          )}
+      </div>
+    );
+  }
+}

--- a/src/modules/reporting/components/reporting-dispute/reporting-dispute.jsx
+++ b/src/modules/reporting/components/reporting-dispute/reporting-dispute.jsx
@@ -13,7 +13,6 @@ import NullStateMessage from "modules/common/components/null-state-message/null-
 import ReportingDisputeForm from "modules/reporting/containers/reporting-dispute-form";
 import ReportingDisputeConfirm from "modules/reporting/components/reporting-dispute-confirm/reporting-dispute-confirm";
 import { TYPE_VIEW } from "modules/markets/constants/link-types";
-import MarketAdditonalDetails from "modules/reporting/components/market-additional-details/market-additional-details";
 import { isEmpty } from "lodash";
 import FormStyles from "modules/common/less/form";
 import Styles from "modules/reporting/components/reporting-report/reporting-report.styles";
@@ -38,7 +37,6 @@ export default class ReportingDispute extends Component {
 
     this.state = {
       currentStep: 0,
-      showingDetails: true,
       gasEstimate: "0",
       isMarketInValid: null,
       selectedOutcome: "",
@@ -53,7 +51,6 @@ export default class ReportingDispute extends Component {
     this.prevPage = this.prevPage.bind(this);
     this.nextPage = this.nextPage.bind(this);
     this.updateState = this.updateState.bind(this);
-    this.toggleDetails = this.toggleDetails.bind(this);
   }
 
   componentWillMount() {
@@ -79,10 +76,6 @@ export default class ReportingDispute extends Component {
 
   updateState(newState) {
     this.setState(newState);
-  }
-
-  toggleDetails() {
-    this.setState({ showingDetails: !this.state.showingDetails });
   }
 
   calculateGasEstimates() {
@@ -139,13 +132,9 @@ export default class ReportingDispute extends Component {
             linkType={TYPE_VIEW}
             buttonText="View"
             showAdditionalDetailsToggle
-            showingDetails={s.showingDetails}
-            toggleDetails={this.toggleDetails}
             showDisputeRound
           />
         )}
-        {!isEmpty(market) &&
-          s.showingDetails && <MarketAdditonalDetails market={market} />}
         {!isEmpty(market) && (
           <article className={FormStyles.Form}>
             {s.currentStep === 0 && (

--- a/src/modules/reporting/components/reporting-report/reporting-report.jsx
+++ b/src/modules/reporting/components/reporting-report/reporting-report.jsx
@@ -15,7 +15,6 @@ import NullStateMessage from "modules/common/components/null-state-message/null-
 import ReportingReportForm from "modules/reporting/components/reporting-report-form/reporting-report-form";
 import ReportingReportConfirm from "modules/reporting/components/reporting-report-confirm/reporting-report-confirm";
 import { TYPE_VIEW } from "modules/markets/constants/link-types";
-import MarketAdditonalDetails from "modules/reporting/components/market-additional-details/market-additional-details";
 import { isEmpty } from "lodash";
 import FormStyles from "modules/common/less/form";
 import Styles from "modules/reporting/components/reporting-report/reporting-report.styles";
@@ -42,7 +41,6 @@ export default class ReportingReport extends Component {
 
     this.state = {
       currentStep: 0,
-      showingDetails: true,
       isMarketInValid: null,
       selectedOutcome: "",
       selectedOutcomeName: "",
@@ -61,7 +59,6 @@ export default class ReportingReport extends Component {
     this.prevPage = this.prevPage.bind(this);
     this.nextPage = this.nextPage.bind(this);
     this.updateState = this.updateState.bind(this);
-    this.toggleDetails = this.toggleDetails.bind(this);
   }
 
   componentWillMount() {
@@ -88,10 +85,6 @@ export default class ReportingReport extends Component {
 
   updateState(newState) {
     this.setState(newState);
-  }
-
-  toggleDetails() {
-    this.setState({ showingDetails: !this.state.showingDetails });
   }
 
   calculateMarketCreationCosts() {
@@ -173,12 +166,8 @@ export default class ReportingReport extends Component {
             linkType={TYPE_VIEW}
             buttonText="View"
             showAdditionalDetailsToggle
-            showingDetails={s.showingDetails}
-            toggleDetails={this.toggleDetails}
           />
         )}
-        {!isEmpty(market) &&
-          s.showingDetails && <MarketAdditonalDetails market={market} />}
         {!isEmpty(market) && (
           <article className={FormStyles.Form}>
             {s.currentStep === 0 && (


### PR DESCRIPTION
- refactor market-preview to have additional details component, to be a state-full component and to manage the toggling state
- removed these pieces from migrate rep form, disputing, and reporting form
- added toggle-height to additional details 

https://app.clubhouse.io/augur/story/7965/move-market-card-additional-details-to-marketpreview-component

https://app.clubhouse.io/augur/story/7966/market-card-additional-details-should-slide-toggle-open