### PR TITLE
market id is returned in result from onSent, use that to store the ma…

### DIFF
--- a/src/modules/markets/actions/submit-new-market.js
+++ b/src/modules/markets/actions/submit-new-market.js
@@ -42,18 +42,18 @@ export function submitNewMarket(newMarket, history, callback = noop) {
             );
             history.push(makePath(TRANSACTIONS));
             dispatch(clearNewMarket());
-          },
-          onSuccess: res => {
-            const marketId = res.callReturn;
             if (hasOrders) {
               dispatch(
                 addMarketLiquidityOrders({
-                  marketId,
+                  marketId: res.callReturn,
                   liquidityOrders: newMarket.orderBook
                 })
               );
               // orders submission will be kicked off from handleMarketCreatedLog event
             }
+          },
+          onSuccess: res => {
+            const marketId = res.callReturn;
             if (callback) callback(null, marketId);
           },
           onFailed: err => {

--- a/test/markets/actions/submit-new-market-test.js
+++ b/test/markets/actions/submit-new-market-test.js
@@ -17,7 +17,7 @@ describe("modules/markets/actions/submit-new-market", () => {
   const buildCreateMarketSuccess = newMarket => {
     const result = {
       createMarket: options => {
-        options.onSent();
+        options.onSent({ hash: "blah blah blah", callReturn: "marketId" });
         options.onSuccess({ callReturn: "marketId" });
       },
       formattedNewMarket: newMarket


### PR DESCRIPTION
…rket liquidity

Surprisingly marketId is returned in result of onSent method call. 
https://app.clubhouse.io/augur/story/16123/fix-edge-case-in-creating-market-liquidity


Not totally sure why the race condition. In testing on 45s private chain code functions correctly. There could be a weird issue with log-handler createMarket comes in before the submit create market onSuccess is called. 

by moving the create liquidity to the onSent we handle the case where the user closes the browser after submitting create market tx.