### PR TITLE
add check for no local storage and mm has changed

### DIFF
--- a/src/modules/app/actions/init-augur.js
+++ b/src/modules/app/actions/init-augur.js
@@ -96,12 +96,19 @@ function loadAccount(dispatch, existing, accountType, callback) {
         usingMetaMask &&
         loggedInAccount !== account
       ) {
+        // local storage does not match mm account
         dispatch(logout());
         account = null;
       } else if (loggedInAccount && loggedInAccount === account) {
+        // local storage matchs mm account
         dispatch(useUnlockedAccount(loggedInAccount));
         account = loggedInAccount;
+      } else if (!loggedInAccount && usingMetaMask && existing !== account) {
+        // no local storage set and logged in account does not match mm account
+        dispatch(logout());
+        account = null;
       } else if (!account && usingMetaMask) {
+        // no mm account signed in
         dispatch(logout());
         account = null;
       }


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/16959/switching-mm-accounts-on-dev-augur-net-doesn-t-log-you-out-of-first-one

test with:
1. dev way- need to change line 23 in load-account-data to have no !
2. prod way

do these things:
1. refreshing
2. switching accounts
3. logging out of mm plugin