### PR TITLE
changed to not do gas estimate if user doesn't have enough balance fo…

### DIFF
--- a/src/modules/markets/helpers/insufficient-funds.js
+++ b/src/modules/markets/helpers/insufficient-funds.js
@@ -7,15 +7,24 @@ export default function insufficientFunds(
   gasCost,
   designatedReportNoShowReputationBond,
   availableEth,
-  availableRep
+  availableRep,
+  formattedInitialLiquidityGas,
+  formattedInitialLiquidityEth,
+  testWithLiquidity = false
 ) {
   let insufficientFundsString = "";
 
   const BNvalidityBond = createBigNumber(
     formatEther(validityBond).fullPrecision
   );
+  const BNLiqGas = createBigNumber(formattedInitialLiquidityGas);
+  const BNLiqEth = createBigNumber(formattedInitialLiquidityEth);
   const BNgasCost = createBigNumber(formatEther(gasCost).fullPrecision);
-  const BNtotalEthCost = BNvalidityBond.plus(BNgasCost);
+  const BNtotalEthCost = testWithLiquidity
+    ? BNvalidityBond.plus(BNgasCost)
+        .plus(BNLiqGas)
+        .plus(BNLiqEth)
+    : BNvalidityBond.plus(BNgasCost);
   const insufficientEth = createBigNumber(availableEth).lt(BNtotalEthCost);
 
   const BNdesignatedReportNoShowReputationBond = createBigNumber(


### PR DESCRIPTION
…r validity and no-show bond, also added in liquidity when calculating if user has sufficient ETH

https://app.clubhouse.io/augur/story/17032/create-market-check-user-balance-before-getting-gas-estimates

verify user gets notified if they don't have enough ETH and REP to create market (gas cost is blank)
verify that gas cost shows up when they do have enough ETH and REP but don't have enough to also pay gas
verify that user is notified that they don't have enough ETH to cover liquidity.