### PR TITLE
fix updating finalize notification if non-market market finalizes

### DIFF
--- a/src/modules/events/actions/log-handlers.js
+++ b/src/modules/events/actions/log-handlers.js
@@ -247,6 +247,8 @@ export const handleMarketFinalizedLog = log => (dispatch, getState) =>
             handleNotificationUpdate(log, dispatch, getState);
           }
         }
+      } else {
+        handleNotificationUpdate(log, dispatch, getState);
       }
     })
   );


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17076/fix-market-finalization-notification-stuck-in-pending-when-market-maker-makes-claim