### PR TITLE
move around spacing so positions and orders look nice

### DIFF
--- a/src/modules/market/components/common/outcome-trading-indicator/outcome-trading-indicator.jsx
+++ b/src/modules/market/components/common/outcome-trading-indicator/outcome-trading-indicator.jsx
@@ -37,10 +37,10 @@ export default function OutcomeTradingIndicator({
   };
 
   const arrowStyles = tradingIndicator => ({
-    ...style,
     top: topSpace(tradingIndicator) + "rem",
     left: "-0.25rem",
-    position: "relative"
+    position: "relative",
+    ...style
   });
 
   return (

--- a/src/modules/market/components/market-positions-list--position/market-positions-list--position.jsx
+++ b/src/modules/market/components/market-positions-list--position/market-positions-list--position.jsx
@@ -61,6 +61,7 @@ export default class MarketPositionsListPosition extends Component {
         }
       >
         <li>{outcomeName || getValue(position, "purchasePrice.formatted")}</li>
+        {hasOrders && <li />}
         <li>{netPositionShares}</li>
         <li>{positionShares}</li>
         <li>{getValue(position, "purchasePrice.formatted")}</li>
@@ -84,7 +85,6 @@ export default class MarketPositionsListPosition extends Component {
         {isExtendedDisplay && (
           <li>{getValue(position, "totalNet.formatted")}</li>
         )}
-        {hasOrders && <li />}
       </ul>
     );
   }

--- a/src/modules/market/components/market-positions-list--position/market-positions-list--position.jsx
+++ b/src/modules/market/components/market-positions-list--position/market-positions-list--position.jsx
@@ -69,6 +69,7 @@ export default class MarketPositionsListPosition extends Component {
           !isMobile && <li>{getValue(outcome, "lastPrice.formatted")}</li>}
         {!isMobile && (
           <li style={{ position: "relative" }}>
+            {getValue(outcome, "lastPrice.formatted")}
             <MarketOutcomeTradingIndicator
               outcome={outcome}
               style={{
@@ -78,9 +79,9 @@ export default class MarketPositionsListPosition extends Component {
                 width: "0.325rem"
               }}
             />
-            {getValue(position, "unrealizedNet.formatted")}
           </li>
         )}
+        {!isMobile && <li>{getValue(position, "unrealizedNet.formatted")} </li>}
         {!isMobile && <li>{getValue(position, "realizedNet.formatted")} </li>}
         {isExtendedDisplay && (
           <li>{getValue(position, "totalNet.formatted")}</li>

--- a/src/modules/market/components/market-positions-list/market-positions-list.jsx
+++ b/src/modules/market/components/market-positions-list/market-positions-list.jsx
@@ -74,6 +74,7 @@ export default class MarketPositionsList extends Component {
             {positions.length > 0 && (
               <ul className={Styles["MarketPositionsList__table-header"]}>
                 <li>Position</li>
+                {hasOrders && <li />}
                 <li>
                   <span>Net Position</span>
                 </li>
@@ -95,7 +96,6 @@ export default class MarketPositionsList extends Component {
                     P/L
                   </span>
                 </li>
-                {hasOrders && <li />}
               </ul>
             )}
             {positions.length > 0 && (


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17175/market-trading-page-positions-and-open-orders-columns-dont-line-up-well

