### PR TITLE
Fix incorrect number of shares in create order notifications

### DIFF
--- a/src/modules/notifications/actions/set-notification-text.js
+++ b/src/modules/notifications/actions/set-notification-text.js
@@ -113,10 +113,8 @@ export default function setNotificationText(notification, callback) {
               );
               notification.description = `Create ${
                 notification.log.orderType
-              } order for ${
-                formatShares(notification.log.quantity).formatted
-              } ${
-                formatShares(notification.log.quantity).denomination
+              } order for ${formatShares(notification.log.amount).formatted} ${
+                formatShares(notification.log.amount).denomination
               } of "${outcomeDescription}" at ${
                 formatEther(notification.log.price).formatted
               } ETH`;


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17335/bell-notification-message-not-showing-to-proper-decimal-place