### PR TITLE
Tomhaile/ch11525/do not allow display to show more decimals

### DIFF
--- a/src/modules/create-market/containers/create-market-form-liquidity-charts.js
+++ b/src/modules/create-market/containers/create-market-form-liquidity-charts.js
@@ -45,6 +45,7 @@ const mapStateToProps = (state, ownProps) => {
     currentTimestamp: selectCurrentTimestamp(state),
     currentTimeInSeconds: selectCurrentTimestampInSeconds(state),
     fixedPrecision: 4,
+    pricePrecision: 4,
     minPrice:
       newMarket.type === SCALAR
         ? createBigNumber(newMarket.scalarSmallNum)

--- a/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
@@ -31,13 +31,14 @@ class MarketOutcomeCandlestick extends React.Component {
     sharedChartMargins: PropTypes.object.isRequired,
     updateSelectedPeriod: PropTypes.func.isRequired,
     updateSelectedRange: PropTypes.func.isRequired,
-    updateSelectedOrderProperties: PropTypes.func.isRequired
+    updateSelectedOrderProperties: PropTypes.func.isRequired,
+    pricePrecision: PropTypes.number.isRequired
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
     const {
       currentTimeInSeconds,
-      fixedPrecision,
+      pricePrecision,
       marketMax,
       marketMin,
       orderBookKeys,
@@ -59,7 +60,7 @@ class MarketOutcomeCandlestick extends React.Component {
       containerHeight,
       containerWidth,
       currentTimeInSeconds,
-      fixedPrecision,
+      pricePrecision,
       marketMax,
       marketMin,
       orderBookKeys,
@@ -163,6 +164,7 @@ class MarketOutcomeCandlestick extends React.Component {
     const {
       currentTimeInSeconds,
       fixedPrecision,
+      pricePrecision,
       isMobile,
       orderBookKeys,
       outcomeName,
@@ -234,7 +236,7 @@ class MarketOutcomeCandlestick extends React.Component {
         chartDim,
         containerHeight,
         containerWidth,
-        fixedPrecision,
+        pricePrecision,
         marketMax,
         marketMin,
         orderBookKeys,
@@ -264,7 +266,6 @@ class MarketOutcomeCandlestick extends React.Component {
         chartDim,
         containerHeight,
         containerWidth,
-        fixedPrecision,
         priceTimeSeries,
         xScale,
         yDomain
@@ -295,7 +296,7 @@ class MarketOutcomeCandlestick extends React.Component {
         chartDim,
         containerHeight,
         containerWidth,
-        fixedPrecision,
+        pricePrecision,
         marketMax,
         marketMin,
         orderBookKeys,
@@ -312,7 +313,7 @@ class MarketOutcomeCandlestick extends React.Component {
         hoveredPrice,
         yScale,
         containerWidth,
-        fixedPrecision
+        pricePrecision
       );
     }
 
@@ -328,6 +329,7 @@ class MarketOutcomeCandlestick extends React.Component {
           close={hoveredPeriod.close}
           priceTimeSeries={priceTimeSeries}
           fixedPrecision={fixedPrecision}
+          pricePrecision={pricePrecision}
           selectedPeriod={selectedPeriod}
           selectedRange={selectedRange}
           updateSelectedPeriod={updateSelectedPeriod}
@@ -441,7 +443,7 @@ function drawTicks({
   candleTicks,
   chartDim,
   containerWidth,
-  fixedPrecision,
+  pricePrecision,
   yDomain,
   yScale
 }) {
@@ -472,7 +474,7 @@ function drawTicks({
     .attr("x2", containerWidth)
     .attr("y1", d => yScale(d))
     .attr("y2", d => yScale(d))
-    .text(d => d.toFixed(fixedPrecision));
+    .text(d => d.toFixed(pricePrecision));
 
   yTicks
     .selectAll("text")
@@ -484,7 +486,7 @@ function drawTicks({
     .attr("y", d => yScale(d))
     .attr("dx", 0)
     .attr("dy", chartDim.tickOffset)
-    .text(d => d.toFixed(fixedPrecision));
+    .text(d => d.toFixed(pricePrecision));
 }
 
 function drawCandles({
@@ -595,7 +597,7 @@ function attachHoverClickHandlers({
   chartDim,
   containerHeight,
   drawableWidth,
-  fixedPrecision,
+  pricePrecision,
   marketMax,
   marketMin,
   orderBookKeys,
@@ -616,13 +618,13 @@ function attachHoverClickHandlers({
       updateHoveredPrice(
         yScale
           .invert(d3.mouse(d3.select("#candlestick_chart").node())[1])
-          .toFixed(fixedPrecision)
+          .toFixed(pricePrecision)
       )
     )
     .on("mouseout", clearCrosshairs)
     .on("click", () => {
       const mouse = d3.mouse(d3.select("#candlestick_chart").node());
-      const orderPrice = yScale.invert(mouse[1]).toFixed(fixedPrecision);
+      const orderPrice = yScale.invert(mouse[1]).toFixed(pricePrecision);
 
       if (orderPrice > marketMin && orderPrice < marketMax) {
         updateSelectedOrderProperties({
@@ -648,7 +650,7 @@ function attachHoverClickHandlers({
       updateHoveredPrice(
         yScale
           .invert(d3.mouse(d3.select("#candlestick_chart").node())[1])
-          .toFixed(fixedPrecision)
+          .toFixed(pricePrecision)
       )
     )
     .on("mouseout", clearCrosshairs);
@@ -660,7 +662,7 @@ function updateHoveredPriceCrosshair(
   hoveredPrice,
   yScale,
   chartWidth,
-  fixedPrecision
+  pricePrecision
 ) {
   if (hoveredPrice == null) {
     d3.select("#candlestick_crosshairs").style("display", "none");
@@ -677,7 +679,7 @@ function updateHoveredPriceCrosshair(
     d3.select("#hovered_candlestick_price_label")
       .attr("x", 0)
       .attr("y", yScale(hoveredPrice) + 12)
-      .text(clampedHoveredPrice.toFixed(fixedPrecision));
+      .text(clampedHoveredPrice.toFixed(pricePrecision));
   }
 }
 

--- a/src/modules/market-charts/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
@@ -19,6 +19,7 @@ export default class MarketOutcomeDepth extends Component {
     marketDepth: PropTypes.object.isRequired,
     orderBookKeys: PropTypes.object.isRequired,
     fixedPrecision: PropTypes.number.isRequired,
+    pricePrecision: PropTypes.number.isRequired,
     updateChartHeaderHeight: PropTypes.func.isRequired,
     updateHoveredPrice: PropTypes.func.isRequired,
     updateHoveredDepth: PropTypes.func.isRequired,
@@ -51,7 +52,7 @@ export default class MarketOutcomeDepth extends Component {
 
   componentDidMount() {
     const {
-      fixedPrecision,
+      pricePrecision,
       marketDepth,
       marketMax,
       marketMin,
@@ -66,7 +67,7 @@ export default class MarketOutcomeDepth extends Component {
       marketDepth,
       orderBookKeys,
       sharedChartMargins,
-      fixedPrecision,
+      pricePrecision,
       marketMin,
       marketMax,
       updateHoveredPrice,
@@ -80,7 +81,6 @@ export default class MarketOutcomeDepth extends Component {
 
   componentWillUpdate(nextProps, nextState) {
     const {
-      fixedPrecision,
       hoveredPrice,
       marketDepth,
       marketMax,
@@ -101,7 +101,6 @@ export default class MarketOutcomeDepth extends Component {
         updateSelectedOrderProperties,
         nextProps.updateSelectedOrderProperties
       ) ||
-      fixedPrecision !== nextProps.fixedPrecision ||
       marketMin !== nextProps.marketMin ||
       marketMax !== nextProps.marketMax ||
       isMobile !== nextProps.isMobile ||
@@ -110,8 +109,8 @@ export default class MarketOutcomeDepth extends Component {
       this.drawDepth({
         marketDepth: nextProps.marketDepth,
         orderBookKeys: nextProps.orderBookKeys,
+        pricePrecision: nextProps.pricePrecision,
         sharedChartMargins: nextProps.sharedChartMargins,
-        fixedPrecision: nextProps.fixedPrecision,
         marketMin: nextProps.marketMin,
         marketMax: nextProps.marketMax,
         updateHoveredPrice: nextProps.updateHoveredPrice,
@@ -133,7 +132,7 @@ export default class MarketOutcomeDepth extends Component {
     ) {
       this.drawCrosshairs({
         hoveredPrice: nextProps.hoveredPrice,
-        fixedPrecision: nextProps.fixedPrecision,
+        pricePrecision: nextProps.pricePrecision,
         marketDepth: nextProps.marketDepth,
         yScale: nextState.yScale,
         xScale: nextState.xScale,
@@ -155,7 +154,7 @@ export default class MarketOutcomeDepth extends Component {
         marketDepth,
         orderBookKeys,
         sharedChartMargins,
-        fixedPrecision,
+        pricePrecision,
         marketMin,
         marketMax,
         updateHoveredPrice,
@@ -169,7 +168,7 @@ export default class MarketOutcomeDepth extends Component {
         sharedChartMargins,
         marketDepth,
         orderBookKeys,
-        fixedPrecision,
+        pricePrecision,
         isMobile,
         marketMax,
         marketMin
@@ -199,7 +198,7 @@ export default class MarketOutcomeDepth extends Component {
         drawParams,
         depthChart,
         orderBookKeys,
-        fixedPrecision,
+        pricePrecision,
         marketMax,
         marketMin,
         isMobile,
@@ -216,7 +215,7 @@ export default class MarketOutcomeDepth extends Component {
         depthChart,
         marketDepth,
         orderBookKeys,
-        fixedPrecision,
+        pricePrecision,
         marketMin,
         marketMax,
         updateHoveredPrice,
@@ -235,7 +234,7 @@ export default class MarketOutcomeDepth extends Component {
 
   drawDepthOnResize() {
     const {
-      fixedPrecision,
+      pricePrecision,
       marketDepth,
       marketMax,
       marketMin,
@@ -249,7 +248,7 @@ export default class MarketOutcomeDepth extends Component {
       marketDepth,
       orderBookKeys,
       sharedChartMargins,
-      fixedPrecision,
+      pricePrecision,
       marketMin,
       marketMax,
       updateHoveredPrice,
@@ -270,7 +269,7 @@ export default class MarketOutcomeDepth extends Component {
         containerWidth,
         marketMin,
         marketMax,
-        fixedPrecision
+        pricePrecision
       } = options;
 
       if (hoveredPrice == null) {
@@ -317,7 +316,7 @@ export default class MarketOutcomeDepth extends Component {
         d3.select("#hovered_price_label")
           .attr("x", xScale(hoveredPrice) + labelOffset)
           .attr("y", containerHeight - sharedChartMargins.bottom - 12)
-          .text(clampedHoveredPrice.toFixed(fixedPrecision));
+          .text(clampedHoveredPrice.toFixed(pricePrecision));
       }
     }
   }
@@ -325,6 +324,7 @@ export default class MarketOutcomeDepth extends Component {
   render() {
     const {
       fixedPrecision,
+      pricePrecision,
       hoveredDepth,
       isMobile,
       headerHeight,
@@ -335,6 +335,7 @@ export default class MarketOutcomeDepth extends Component {
       <section className={Styles.MarketOutcomeDepth}>
         <MarketOutcomeChartHeaderDepth
           fixedPrecision={fixedPrecision}
+          pricePrecision={pricePrecision}
           hoveredDepth={hoveredDepth}
           isMobile={isMobile}
           headerHeight={headerHeight}
@@ -468,7 +469,7 @@ function drawTicks(options) {
     drawParams,
     depthChart,
     orderBookKeys,
-    fixedPrecision,
+    pricePrecision,
     isMobile,
     marketMax,
     marketMin,
@@ -527,7 +528,7 @@ function drawTicks(options) {
       .attr("dx", midOffset)
       .attr("dy", 0)
       .text(
-        orderBookKeys.mid && `${orderBookKeys.mid.toFixed(fixedPrecision)} ETH`
+        orderBookKeys.mid && `${orderBookKeys.mid.toFixed(pricePrecision)} ETH`
       );
   }
   if (hasOrders) {
@@ -550,7 +551,7 @@ function drawTicks(options) {
       .attr("y", d => drawParams.yScale(d))
       .attr("dx", 0)
       .attr("dy", drawParams.chartDim.tickOffset)
-      .text(d => d.toFixed(fixedPrecision));
+      .text(d => d.toFixed(pricePrecision));
   }
 
   // X Axis
@@ -672,7 +673,7 @@ function attachHoverClickHandlers(options) {
     drawParams,
     depthChart,
     marketDepth,
-    fixedPrecision,
+    pricePrecision,
     marketMin,
     marketMax,
     updateHoveredPrice,
@@ -692,7 +693,7 @@ function attachHoverClickHandlers(options) {
       // Determine closest order
       const hoveredPrice = drawParams.xScale
         .invert(mouse[0])
-        .toFixed(fixedPrecision);
+        .toFixed(pricePrecision);
 
       updateHoveredPrice(hoveredPrice);
     })
@@ -700,7 +701,7 @@ function attachHoverClickHandlers(options) {
       const mouse = d3.mouse(d3.select("#depth_chart").node());
       const orderPrice = drawParams.xScale
         .invert(mouse[0])
-        .toFixed(fixedPrecision);
+        .toFixed(pricePrecision);
       const nearestFillingOrder = nearestCompletelyFillingOrder(
         orderPrice,
         marketDepth

--- a/src/modules/market-charts/components/market-outcome-charts--header-candlestick/market-outcome-charts--header-candlestick.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--header-candlestick/market-outcome-charts--header-candlestick.jsx
@@ -12,6 +12,7 @@ const MarketOutcomeCandlestickHeader = ({
   isMobile,
   volume,
   fixedPrecision,
+  pricePrecision,
   open,
   high,
   low,
@@ -57,7 +58,7 @@ const MarketOutcomeCandlestickHeader = ({
             className={StylesHeader[`MarketOutcomeChartsHeader__stat-value`]}
           >
             {open ? (
-              open.toFixed(fixedPrecision).toString()
+              open.toFixed(pricePrecision).toString()
             ) : (
               <span>&mdash;</span>
             )}
@@ -73,7 +74,7 @@ const MarketOutcomeCandlestickHeader = ({
             className={StylesHeader[`MarketOutcomeChartsHeader__stat-value`]}
           >
             {high ? (
-              high.toFixed(fixedPrecision).toString()
+              high.toFixed(pricePrecision).toString()
             ) : (
               <span>&mdash;</span>
             )}
@@ -89,7 +90,7 @@ const MarketOutcomeCandlestickHeader = ({
             className={StylesHeader[`MarketOutcomeChartsHeader__stat-value`]}
           >
             {low ? (
-              low.toFixed(fixedPrecision).toString()
+              low.toFixed(pricePrecision).toString()
             ) : (
               <span>&mdash;</span>
             )}
@@ -105,7 +106,7 @@ const MarketOutcomeCandlestickHeader = ({
             className={StylesHeader[`MarketOutcomeChartsHeader__stat-value`]}
           >
             {close ? (
-              close.toFixed(fixedPrecision).toString()
+              close.toFixed(pricePrecision).toString()
             ) : (
               <span>&mdash;</span>
             )}
@@ -132,6 +133,7 @@ const MarketOutcomeCandlestickHeader = ({
 MarketOutcomeCandlestickHeader.propTypes = {
   outcomeName: PropTypes.string,
   fixedPrecision: PropTypes.number.isRequired,
+  pricePrecision: PropTypes.number.isRequired,
   isMobile: PropTypes.bool.isRequired,
   updateSelectedPeriod: PropTypes.func.isRequired,
   updateSelectedRange: PropTypes.func.isRequired,

--- a/src/modules/market-charts/components/market-outcome-charts--header-depth/market-outcome-charts--header-depth.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--header-depth/market-outcome-charts--header-depth.jsx
@@ -12,6 +12,7 @@ export default class MarketOutcomeDepthHeader extends Component {
   static propTypes = {
     hoveredDepth: PropTypes.array.isRequired,
     fixedPrecision: PropTypes.number.isRequired,
+    pricePrecision: PropTypes.number.isRequired,
     isMobile: PropTypes.bool.isRequired,
     headerHeight: PropTypes.number.isRequired,
     updateChartHeaderHeight: PropTypes.func.isRequired
@@ -23,7 +24,13 @@ export default class MarketOutcomeDepthHeader extends Component {
   }
 
   render() {
-    const { headerHeight, hoveredDepth, isMobile, fixedPrecision } = this.props;
+    const {
+      headerHeight,
+      hoveredDepth,
+      isMobile,
+      fixedPrecision,
+      pricePrecision
+    } = this.props;
 
     if (isMobile) {
       return <section style={{ minHeight: headerHeight }} />;
@@ -63,7 +70,7 @@ export default class MarketOutcomeDepthHeader extends Component {
             </span>
             <span className={Styles["MarketOutcomeChartsHeader__stat-value"]}>
               {isNumber(hoveredDepth[1]) ? (
-                hoveredDepth[1].toFixed(fixedPrecision).toString()
+                hoveredDepth[1].toFixed(pricePrecision).toString()
               ) : (
                 <span>&mdash;</span>
               )}

--- a/src/modules/market-charts/components/market-outcome-charts--header-orders/market-outcome-charts--header-orders.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--header-orders/market-outcome-charts--header-orders.jsx
@@ -53,7 +53,6 @@ const MarketOutcomeChartsHeaderOrders = p => (
 export default MarketOutcomeChartsHeaderOrders;
 
 MarketOutcomeChartsHeaderOrders.propTypes = {
-  fixedPrecision: PropTypes.number.isRequired,
   updatePrecision: PropTypes.func,
   isMobile: PropTypes.bool.isRequired,
   headerHeight: PropTypes.number.isRequired

--- a/src/modules/market-charts/components/market-outcome-charts--midpoint/market-outcome-charts--midpoint.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--midpoint/market-outcome-charts--midpoint.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import Styles from "modules/market-charts/components/market-outcome-charts--midpoint/market-outcome-charts--midpoint.styles";
 
 const Midpoint = props => {
-  const { orderBookKeys, fixedPrecision, hasOrders } = props;
+  const { orderBookKeys, pricePrecision, hasOrders } = props;
 
   return (
     <section>
@@ -11,7 +11,7 @@ const Midpoint = props => {
         <div className={Styles.MarketOutcomeMidpoint}>
           <div className={Styles.MarketOutcomeMidpointLine} />
           <div className={Styles.MarketOutcomeMidpointValue}>
-            {`${orderBookKeys.mid.toFixed(fixedPrecision)} ETH`}
+            {`${orderBookKeys.mid.toFixed(pricePrecision)} ETH`}
           </div>
         </div>
       )}
@@ -27,7 +27,7 @@ const Midpoint = props => {
 Midpoint.propTypes = {
   orderBookKeys: PropTypes.object.isRequired,
   hasOrders: PropTypes.bool.isRequired,
-  fixedPrecision: PropTypes.number.isRequired
+  pricePrecision: PropTypes.number.isRequired
 };
 
 export default Midpoint;

--- a/src/modules/market-charts/components/market-outcome-charts--orders/market-outcome-charts--orders.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--orders/market-outcome-charts--orders.jsx
@@ -25,6 +25,7 @@ export default class MarketOutcomeChartsOrders extends Component {
     sharedChartMargins: PropTypes.object.isRequired,
     orderBook: PropTypes.object.isRequired,
     fixedPrecision: PropTypes.number.isRequired,
+    pricePrecision: PropTypes.number.isRequired,
     updateHoveredPrice: PropTypes.func.isRequired,
     updateSelectedOrderProperties: PropTypes.func.isRequired,
     updatePrecision: PropTypes.func,
@@ -64,6 +65,7 @@ export default class MarketOutcomeChartsOrders extends Component {
   render() {
     const {
       fixedPrecision,
+      pricePrecision,
       orderBook,
       sharedChartMargins,
       updateHoveredPrice,
@@ -84,7 +86,6 @@ export default class MarketOutcomeChartsOrders extends Component {
         style={{ paddingBottom: sharedChartMargins.bottom - 4 }}
       >
         <MarketOutcomeChartHeaderOrders
-          fixedPrecision={fixedPrecision}
           updatePrecision={updatePrecision}
           isMobile={isMobile}
           headerHeight={headerHeight}
@@ -157,10 +158,10 @@ export default class MarketOutcomeChartsOrders extends Component {
                   }
                 >
                   <span>
-                    {parseFloat(order.price.value.toFixed(fixedPrecision))}
+                    {parseFloat(order.price.value.toFixed(pricePrecision))}
                     <span style={{ color: "#6d1d3d", marginLeft: ".5px" }}>
                       {findTrailingZeros(
-                        order.price.value.toFixed(fixedPrecision)
+                        order.price.value.toFixed(pricePrecision)
                       )}
                     </span>
                   </span>
@@ -189,7 +190,7 @@ export default class MarketOutcomeChartsOrders extends Component {
           <MarketOutcomeMidpoint
             hasOrders={hasOrders}
             orderBookKeys={orderBookKeys}
-            fixedPrecision={fixedPrecision}
+            pricePrecision={pricePrecision}
           />
         </div>
         <div
@@ -256,10 +257,10 @@ export default class MarketOutcomeChartsOrders extends Component {
                   }
                 >
                   <span>
-                    {parseFloat(order.price.value.toFixed(fixedPrecision))}
+                    {parseFloat(order.price.value.toFixed(pricePrecision))}
                     <span style={{ color: "#135045", marginLeft: ".5px" }}>
                       {findTrailingZeros(
-                        order.price.value.toFixed(fixedPrecision)
+                        order.price.value.toFixed(pricePrecision)
                       )}
                     </span>
                   </span>

--- a/src/modules/market-charts/components/market-outcome-charts/market-outcome-charts.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts/market-outcome-charts.jsx
@@ -35,7 +35,8 @@ export default class MarketOutcomeCharts extends Component {
     priceTimeSeries: PropTypes.array,
     selectedOutcome: PropTypes.object.isRequired,
     updatePrecision: PropTypes.func,
-    updateSelectedOrderProperties: PropTypes.func.isRequired
+    updateSelectedOrderProperties: PropTypes.func.isRequired,
+    pricePrecision: PropTypes.number.isRequired
   };
 
   constructor(props) {
@@ -222,6 +223,7 @@ export default class MarketOutcomeCharts extends Component {
       excludeCandlestick,
       isMobile,
       fixedPrecision,
+      pricePrecision,
       updatePrecision,
       hasPriceHistory
     } = this.props;
@@ -255,6 +257,7 @@ export default class MarketOutcomeCharts extends Component {
                 selectedPeriod={s.selectedPeriod}
                 selectedRange={s.selectedRange}
                 fixedPrecision={fixedPrecision}
+                pricePrecision={pricePrecision}
                 orderBookKeys={orderBookKeys}
                 marketMax={maxPrice}
                 marketMin={minPrice}
@@ -279,6 +282,7 @@ export default class MarketOutcomeCharts extends Component {
                 priceTimeSeries={priceTimeSeries}
                 sharedChartMargins={s.sharedChartMargins}
                 fixedPrecision={fixedPrecision}
+                pricePrecision={pricePrecision}
                 orderBookKeys={orderBookKeys}
                 marketDepth={marketDepth}
                 marketMax={maxPrice}
@@ -299,6 +303,7 @@ export default class MarketOutcomeCharts extends Component {
                 isMobile={isMobile}
                 sharedChartMargins={s.sharedChartMargins}
                 fixedPrecision={fixedPrecision}
+                pricePrecision={pricePrecision}
                 orderBook={orderBook}
                 marketMidpoint={orderBookKeys.mid}
                 hoveredPrice={s.hoveredPrice}

--- a/src/modules/market-charts/components/market-outcomes-chart/market-outcomes-chart.jsx
+++ b/src/modules/market-charts/components/market-outcomes-chart/market-outcomes-chart.jsx
@@ -18,10 +18,10 @@ export default class MarketOutcomesChart extends Component {
     minPrice: PropTypes.number,
     outcomes: PropTypes.array.isRequired,
     updateSelectedOutcome: PropTypes.func.isRequired,
-    fixedPrecision: PropTypes.number.isRequired,
     hasPriceHistory: PropTypes.bool.isRequired,
     bucketedPriceTimeSeries: PropTypes.object.isRequired,
-    selectedOutcome: PropTypes.any // NOTE -- There is a PR in the prop-types lib to handle null values, but until then..
+    selectedOutcome: PropTypes.any, // NOTE -- There is a PR in the prop-types lib to handle null values, but until then..
+    pricePrecision: PropTypes.number.isRequired
   };
 
   constructor(props) {
@@ -45,23 +45,17 @@ export default class MarketOutcomesChart extends Component {
   }
 
   componentWillUpdate(nextProps, nextState) {
-    const { outcomes, fixedPrecision } = this.props;
+    const { outcomes } = this.props;
 
-    if (
-      !isEqual(outcomes, nextProps.outcomes) ||
-      fixedPrecision !== nextProps.fixedPrecision
-    )
-      this.drawChart(nextProps);
+    if (!isEqual(outcomes, nextProps.outcomes)) this.drawChart(nextProps);
 
     if (
       !isEqual(this.state.hoveredLocation, nextState.hoveredLocation) ||
-      !isEqual(this.state.drawParams, nextState.drawParams) ||
-      fixedPrecision !== nextProps.fixedPrecision
+      !isEqual(this.state.drawParams, nextState.drawParams)
     ) {
       updateHoveredLocationCrosshair({
         hoveredLocation: nextState.hoveredLocation,
-        drawParams: nextState.drawParams,
-        fixedPrecision: nextProps.fixedPrecision
+        drawParams: nextState.drawParams
       });
     }
   }
@@ -78,12 +72,12 @@ export default class MarketOutcomesChart extends Component {
     creationTime,
     currentTimestamp,
     estimatedInitialPrice,
-    fixedPrecision,
     maxPrice,
     minPrice,
     outcomes,
     hasPriceHistory,
-    bucketedPriceTimeSeries
+    bucketedPriceTimeSeries,
+    pricePrecision
   }) {
     if (this.outcomesChart) {
       const drawParams = determineDrawParams({
@@ -108,7 +102,7 @@ export default class MarketOutcomesChart extends Component {
       drawTicks({
         drawParams,
         chart,
-        fixedPrecision
+        pricePrecision
       });
 
       drawXAxisLabels({
@@ -156,6 +150,7 @@ export default class MarketOutcomesChart extends Component {
   }
 
   render() {
+    const { pricePrecision } = this.props;
     const s = this.state;
 
     return (
@@ -171,7 +166,7 @@ export default class MarketOutcomesChart extends Component {
                   {s.hoveredOutcome.name}
                 </span>
                 <span className={Styles.MarketOutcomesChart__price}>
-                  last: {s.hoveredOutcome.price.toFixed(4)} eth
+                  last: {s.hoveredOutcome.price.toFixed(pricePrecision)} eth
                 </span>
                 <span className={Styles.MarketOutcomesChart__instruction}>
                   click to view more information about this outcome
@@ -237,7 +232,7 @@ function determineDrawParams(options) {
 }
 
 function drawTicks(options) {
-  const { drawParams, chart, fixedPrecision } = options;
+  const { drawParams, chart, pricePrecision } = options;
 
   // Y axis
   //  Bounds
@@ -295,7 +290,7 @@ function drawTicks(options) {
     .attr("y", d => drawParams.yScale(d))
     .attr("dx", 0)
     .attr("dy", drawParams.chartDim.tickOffset)
-    .text(d => d.toFixed(fixedPrecision));
+    .text(d => d.toFixed(pricePrecision));
 }
 
 function drawXAxisLabels(options) {
@@ -389,7 +384,7 @@ function attachHoverHandler(options) {
 }
 
 function updateHoveredLocationCrosshair(options) {
-  const { drawParams, hoveredLocation, fixedPrecision } = options;
+  const { drawParams, hoveredLocation, pricePrecision } = options;
 
   if (hoveredLocation.length === 0) {
     d3.select("#priceTimeSeries_crosshairs").style("display", "none");
@@ -409,7 +404,7 @@ function updateHoveredLocationCrosshair(options) {
     d3.select("#hovered_priceTimeSeries_price_label")
       .attr("x", 0)
       .attr("y", drawParams.yScale(hoveredLocation[1]) + 12)
-      .text(hoveredLocation[1].toFixed(fixedPrecision));
+      .text(hoveredLocation[1].toFixed(pricePrecision));
   }
 }
 

--- a/src/modules/market/components/market-view/market-view.jsx
+++ b/src/modules/market/components/market-view/market-view.jsx
@@ -25,7 +25,8 @@ export default class MarketView extends Component {
     location: PropTypes.object.isRequired,
     isLogged: PropTypes.bool,
     marketType: PropTypes.string,
-    loadingState: PropTypes.any
+    loadingState: PropTypes.any,
+    pricePrecision: PropTypes.number.isRequired
   };
 
   constructor(props) {
@@ -142,7 +143,7 @@ export default class MarketView extends Component {
   }
 
   render() {
-    const { description, marketId, location } = this.props;
+    const { description, marketId, location, pricePrecision } = this.props;
     const s = this.state;
 
     return (
@@ -168,6 +169,7 @@ export default class MarketView extends Component {
               fixedPrecision={s.fixedPrecision}
               selectedOutcome={s.selectedOutcome}
               updateSelectedOutcome={this.updateSelectedOutcome}
+              pricePrecision={pricePrecision}
             />
           )}
           {s.selectedOutcome !== null && (
@@ -177,6 +179,7 @@ export default class MarketView extends Component {
               updatePrecision={this.updatePrecision}
               selectedOutcome={s.selectedOutcome}
               updateSelectedOrderProperties={this.updateSelectedOrderProperties}
+              pricePrecision={pricePrecision}
             />
           )}
         </div>

--- a/src/modules/market/containers/market-view.js
+++ b/src/modules/market/containers/market-view.js
@@ -17,6 +17,7 @@ const mapStateToProps = (state, ownProps) => {
   } = state;
   const marketId = parseQuery(ownProps.location.search)[MARKET_ID_PARAM_NAME];
   const market = selectMarket(marketId);
+  const pricePrecision = market.tickSize ? market.tickSize.length - 2 : 4;
 
   return {
     isConnected: connection.isConnected && universe.id != null,
@@ -28,7 +29,8 @@ const mapStateToProps = (state, ownProps) => {
     orderBooks,
     isMobile: appStatus.isMobile,
     marketId,
-    marketsData
+    marketsData,
+    pricePrecision
   };
 };
 

--- a/src/modules/market/containers/market-view.js
+++ b/src/modules/market/containers/market-view.js
@@ -17,7 +17,9 @@ const mapStateToProps = (state, ownProps) => {
   } = state;
   const marketId = parseQuery(ownProps.location.search)[MARKET_ID_PARAM_NAME];
   const market = selectMarket(marketId);
-  const pricePrecision = market.tickSize ? market.tickSize.length - 2 : 4;
+  const pricePrecision = market.tickSize
+    ? market.tickSize.split(".")[0].length
+    : 4;
 
   return {
     isConnected: connection.isConnected && universe.id != null,

--- a/src/modules/market/containers/market-view.js
+++ b/src/modules/market/containers/market-view.js
@@ -5,6 +5,7 @@ import { loadFullMarket } from "modules/markets/actions/load-full-market";
 import { selectMarket } from "modules/markets/selectors/market";
 import parseQuery from "modules/routes/helpers/parse-query";
 import { MARKET_ID_PARAM_NAME } from "modules/routes/constants/param-names";
+import getPrecision from "utils/get-number-precision";
 
 const mapStateToProps = (state, ownProps) => {
   const {
@@ -17,9 +18,7 @@ const mapStateToProps = (state, ownProps) => {
   } = state;
   const marketId = parseQuery(ownProps.location.search)[MARKET_ID_PARAM_NAME];
   const market = selectMarket(marketId);
-  const pricePrecision = market.tickSize
-    ? market.tickSize.split(".")[0].length
-    : 4;
+  const pricePrecision = market && getPrecision(market.tickSize, 4);
 
   return {
     isConnected: connection.isConnected && universe.id != null,

--- a/src/utils/get-number-precision-test.js
+++ b/src/utils/get-number-precision-test.js
@@ -1,0 +1,62 @@
+import getPrecision from "utils/get-number-precision";
+
+describe("utils/format-number.js", () => {
+  const values = [
+    {
+      value: null,
+      defaultValue: 4,
+      result: 4
+    },
+    {
+      value: null,
+      defaultValue: 3,
+      result: 3
+    },
+    {
+      value: 0.0001,
+      defaultValue: 1,
+      result: 4
+    },
+    {
+      value: 0.001,
+      defaultValue: 1,
+      result: 3
+    },
+    {
+      value: 0.01,
+      defaultValue: 1,
+      result: 2
+    },
+    {
+      value: 0.1,
+
+      defaultValue: 3,
+      result: 1
+    },
+    {
+      value: 1.0,
+      defaultValue: 3,
+      result: 1
+    },
+    {
+      value: 1,
+      defaultValue: 3,
+      result: 0
+    },
+    {
+      value: 10,
+      defaultValue: 3,
+      result: 0
+    }
+  ];
+
+  values.forEach(test => {
+    describe(`test precision: ${test.value}`, () => {
+      test("number should have specific precision", () => {
+        expect(getPrecision(test.value, test.defaultValue)).toEqual(
+          test.result
+        );
+      });
+    });
+  });
+});

--- a/src/utils/get-number-precision.js
+++ b/src/utils/get-number-precision.js
@@ -1,0 +1,7 @@
+// get the precision of the number, the length to the right of the decimal
+export default function getPrecision(value, defaultValue) {
+  if (!value) return defaultValue;
+  const values = value.toString().split(".");
+  if (values.length === 1) return 0; // no decimal
+  return values[1].length;
+}


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/11525/do-not-allow-display-to-show-more-decimals-than-supported-by-the-contracts


(+ | -) buttons on order book only affect quantity. Price precision is determined by numTicks. 4 for YesNo and Categorical markets, Scalar markets are determined by market creator.