### PR TITLE
close modal when transfer assets is called and tx is sent to be signed

### DIFF
--- a/src/modules/account/containers/account-withdraw.js
+++ b/src/modules/account/containers/account-withdraw.js
@@ -17,8 +17,10 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  transferFunds: (amount, asset, to) =>
-    dispatch(transferFunds(amount, asset, to)),
+  transferFunds: (amount, asset, to) => {
+    dispatch(closeModal());
+    dispatch(transferFunds(amount, asset, to));
+  },
   withdrawReviewModal: modal =>
     dispatch(
       updateModal({


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17389/closemodal-isn-t-called-when-user-withdraws-eth-rep