### PR TITLE
don't make gasPrice field required, just show blank while populating …

### DIFF
--- a/src/modules/modal/components/modal-gas-price.jsx
+++ b/src/modules/modal/components/modal-gas-price.jsx
@@ -12,9 +12,9 @@ export default class ModalGasPrice extends Component {
   static propTypes = {
     closeModal: PropTypes.func.isRequired,
     saveModal: PropTypes.func.isRequired,
-    safeLow: PropTypes.number.isRequired,
-    average: PropTypes.number.isRequired,
-    fast: PropTypes.number.isRequired,
+    safeLow: PropTypes.number,
+    average: PropTypes.number,
+    fast: PropTypes.number,
     userDefinedGasPrice: PropTypes.number
   };
 


### PR DESCRIPTION
…values from augur.js

https://app.clubhouse.io/augur/story/17455/gasprice-form-throwing-errors-on-dev-augur-net

Only issue on initial load (test on dev.augur.net, some reason it's slow). After the values are filled in by augur.js the form won't have an issues even after user refreshes.