### PR TITLE
fix color for standard gasPrice, needs to be white where non standard…

### DIFF
--- a/src/modules/app/components/gas-price-edit/gas-price-edit.jsx
+++ b/src/modules/app/components/gas-price-edit/gas-price-edit.jsx
@@ -6,6 +6,7 @@ import { MODAL_GAS_PRICE } from "modules/modal/constants/modal-types";
 
 import Styles from "modules/app/components/gas-price-edit/gas-price-edit.styles";
 
+const STANDARD = "Standard";
 export default class GasPriceEdit extends Component {
   static propTypes = {
     updateModal: PropTypes.func.isRequired,
@@ -27,6 +28,8 @@ export default class GasPriceEdit extends Component {
 
   render() {
     const { userDefinedGasPrice, gasPriceSpeed } = this.props;
+    console.log("gasPriceSpeed", gasPriceSpeed);
+
     return (
       <div className={classNames(Styles.GasPriceEdit)}>
         <div
@@ -40,7 +43,14 @@ export default class GasPriceEdit extends Component {
             <div className={Styles.GasPriceEdit__price}>
               {userDefinedGasPrice}
             </div>
-            <div className={Styles.GasPriceEdit__description}>
+            <div
+              className={classNames({
+                [Styles.GasPriceEdit__description_non_standard]:
+                  gasPriceSpeed !== STANDARD,
+                [Styles.GasPriceEdit__description_standard]:
+                  gasPriceSpeed === STANDARD
+              })}
+            >
               ({gasPriceSpeed})
             </div>
             <div className={Styles.GasPriceEdit__edit}> Edit </div>

--- a/src/modules/app/components/gas-price-edit/gas-price-edit.jsx
+++ b/src/modules/app/components/gas-price-edit/gas-price-edit.jsx
@@ -28,7 +28,6 @@ export default class GasPriceEdit extends Component {
 
   render() {
     const { userDefinedGasPrice, gasPriceSpeed } = this.props;
-    console.log("gasPriceSpeed", gasPriceSpeed);
 
     return (
       <div className={classNames(Styles.GasPriceEdit)}>

--- a/src/modules/app/components/gas-price-edit/gas-price-edit.styles.less
+++ b/src/modules/app/components/gas-price-edit/gas-price-edit.styles.less
@@ -1,4 +1,4 @@
-@import (reference) '~assets/styles/shared';
+@import (reference) "~assets/styles/shared";
 
 .GasPriceEdit {
   align-items: center;
@@ -53,8 +53,15 @@
   white-space: nowrap;
 }
 
-.GasPriceEdit__description {
+.GasPriceEdit__description_non_standard {
   color: @color-yellow-alert;
+  font-size: 10px;
+  font-weight: bold;
+  margin-right: 4px;
+}
+
+.GasPriceEdit__description_standard {
+  color: @color-white;
   font-size: 10px;
   font-weight: bold;
   margin-right: 4px;


### PR DESCRIPTION
… is yellow


https://app.clubhouse.io/augur/story/17453/gasprice-text-indicator-doesn-t-change-color