### PR TITLE
added light grey volume lines to give user scale

### DIFF
--- a/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
@@ -584,7 +584,7 @@ function drawVolume({
     .data(volumeTicks)
     .enter()
     .append("text")
-    .attr("class", "tick-value")
+    .attr("class", "tick-value-volume")
     .attr("x", containerWidth - 90)
     .attr("y", d => yVolumeScale(d.volume) - 4)
     .text(d => d.volume.toFixed(4));

--- a/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
@@ -9,7 +9,7 @@ import { sortBy, maxBy } from "lodash";
 
 import findPeriodSeriesBounds from "modules/markets/helpers/find-period-series-bounds";
 import MarketOutcomeChartsHeaderCandlestick from "modules/market-charts/components/market-outcome-charts--header-candlestick/market-outcome-charts--header-candlestick";
-
+import { ONE } from "modules/trades/constants/numbers";
 import { BUY, SELL } from "modules/transactions/constants/types";
 
 import Styles from "modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles";
@@ -585,9 +585,14 @@ function drawVolume({
     .enter()
     .append("text")
     .attr("class", "tick-value-volume")
-    .attr("x", containerWidth - 90)
+    .attr("x", containerWidth - 110)
     .attr("y", d => yVolumeScale(d.volume) - 4)
-    .text(d => d.volume.toFixed(0) + ` ETH`);
+    .text(d => {
+      if (createBigNumber(d.volume).gte(ONE)) {
+        return d.volume.toFixed(0) + ` ETH`;
+      }
+      return d.volume.toFixed(4) + ` ETH`;
+    });
 }
 
 function drawXAxisLabels({

--- a/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
@@ -589,7 +589,7 @@ function drawVolume({
     .attr("y", d => yVolumeScale(d.volume) - 4)
     .text(d => {
       if (createBigNumber(d.volume).gte(ONE)) {
-        return d.volume.toFixed(0) + ` ETH`;
+        return d.volume.toFixed(1) + ` ETH`;
       }
       return d.volume.toFixed(4) + ` ETH`;
     });

--- a/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
@@ -587,7 +587,7 @@ function drawVolume({
     .attr("class", "tick-value-volume")
     .attr("x", containerWidth - 90)
     .attr("y", d => yVolumeScale(d.volume) - 4)
-    .text(d => d.volume.toFixed(4));
+    .text(d => d.volume.toFixed(0) + ` ETH`);
 }
 
 function drawXAxisLabels({

--- a/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles.less
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles.less
@@ -71,6 +71,13 @@
       fill: @color-lightgray;
     }
 
+    .tick-value-volume {
+      &:extend(.caps--extra-small all);
+
+      fill: @color-lightgray;
+      opacity: 0.55;
+    }
+
     rect {
       &.up-period {
         fill: @color-positive;

--- a/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles.less
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.styles.less
@@ -46,6 +46,12 @@
       stroke-width: 2px;
     }
 
+    .tick-line-volume {
+      opacity: 0.25;
+      stroke: @color-gray;
+      stroke-width: 1px;
+    }
+
     .overlay {
       fill: none;
       pointer-events: visible;


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/14843/grey-volume-bar-on-price-chart-doesn-t-appear-to-be-accurate

volume lines

![screen shot 2018-10-12 at 2 17 27 pm](https://user-images.githubusercontent.com/3970376/46889555-a6125380-ce29-11e8-998a-ca5ec7b47e20.png)
