### PR TITLE
johndanz/ch14970/limit-the-number-of-decimals-in-the-order

### DIFF
--- a/src/modules/trades/constants/numbers.js
+++ b/src/modules/trades/constants/numbers.js
@@ -5,3 +5,4 @@ export const ONE = createBigNumber(1, 10);
 export const TWO = createBigNumber(2, 10);
 export const TEN = createBigNumber(10, 10);
 export const TEN_TO_THE_EIGHTEENTH_POWER = TEN.exponentiatedBy(18);
+export const MIN_QUANTITY = createBigNumber("0.00000001");


### PR DESCRIPTION
converted Quantity to only allow up to 8 decimal places in the input, will still allow greater than 8 decimals if the order is on the book and clicked on. will display 8 decimals rounded, however the actual value will be sent to the transaction to avoid leaving any dust on the book.