### PR TITLE
phoebemirman/ch17544/categorical-market-card-outcomes-expand-and

### DIFF
--- a/src/modules/market/components/market-basics/market-basics.jsx
+++ b/src/modules/market/components/market-basics/market-basics.jsx
@@ -125,7 +125,10 @@ const MarketBasics = ({
         )}
 
         {marketType === CATEGORICAL && (
-          <MarketOutcomesCategorical outcomes={p.outcomes} isMobileSmall={p.isMobileSmall}/>
+          <MarketOutcomesCategorical
+            outcomes={p.outcomes}
+            isMobileSmall={p.isMobileSmall}
+          />
         )}
       </div>
     </article>
@@ -152,7 +155,7 @@ MarketBasics.propTypes = {
   hideReportEndingIndicator: PropTypes.bool,
   showDisputeRound: PropTypes.bool,
   tags: PropTypes.arrayOf(PropTypes.string),
-  isMobileSmall: PropTypes.bool,
+  isMobileSmall: PropTypes.bool
 };
 
 MarketBasics.defaultProps = {

--- a/src/modules/market/components/market-basics/market-basics.jsx
+++ b/src/modules/market/components/market-basics/market-basics.jsx
@@ -125,7 +125,7 @@ const MarketBasics = ({
         )}
 
         {marketType === CATEGORICAL && (
-          <MarketOutcomesCategorical outcomes={p.outcomes} />
+          <MarketOutcomesCategorical outcomes={p.outcomes} isMobileSmall={p.isMobileSmall}/>
         )}
       </div>
     </article>
@@ -151,7 +151,8 @@ MarketBasics.propTypes = {
   cardStyle: PropTypes.string,
   hideReportEndingIndicator: PropTypes.bool,
   showDisputeRound: PropTypes.bool,
-  tags: PropTypes.arrayOf(PropTypes.string)
+  tags: PropTypes.arrayOf(PropTypes.string),
+  isMobileSmall: PropTypes.bool,
 };
 
 MarketBasics.defaultProps = {

--- a/src/modules/market/components/market-basics/market-basics.jsx
+++ b/src/modules/market/components/market-basics/market-basics.jsx
@@ -165,7 +165,8 @@ MarketBasics.defaultProps = {
   disputeInfo: null,
   cardStyle: null,
   reportingState: null,
-  scalarDenomination: null
+  scalarDenomination: null,
+  isMobileSmall: false
 };
 
 export default MarketBasics;

--- a/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.jsx
+++ b/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.jsx
@@ -15,14 +15,10 @@ const CategoricalOutcome = ({ className, outcome, isMobileSmall }) => (
       textOverflow: "ellipsis"
     }}
   >
-    <span
-      className={Styles["MarketOutcomesCategorical__outcome-name"]}
-    >
+    <span className={Styles["MarketOutcomesCategorical__outcome-name"]}>
       {isMobileSmall ? outcome.name[0] + "... " : outcome.name}
     </span>
-    <span
-      className={Styles["MarketOutcomesCategorical__outcome-value"]}
-    >
+    <span className={Styles["MarketOutcomesCategorical__outcome-value"]}>
       {getValue(outcome, "lastPricePercent.full")}
     </span>
     <span>&nbsp;&nbsp;</span>
@@ -57,8 +53,8 @@ class MarketOutcomesCategorical extends Component {
     const { outcomes, isMobileSmall } = this.props;
     const totalOutcomes = outcomes.length;
 
-    const numOutcomesToShow = !isMobileSmall ? 3 : 6
-    
+    const numOutcomesToShow = !isMobileSmall ? 3 : 6;
+
     const displayShowMore = totalOutcomes > numOutcomesToShow;
     const showMoreText = this.state.isOpen
       ? `- ${totalOutcomes - numOutcomesToShow} less`
@@ -68,7 +64,7 @@ class MarketOutcomesCategorical extends Component {
       minHeight: this.state.outcomeWrapperHeight
     };
 
-    console.log(isMobileSmall)
+    console.log(isMobileSmall);
 
     return (
       <div
@@ -106,7 +102,11 @@ class MarketOutcomesCategorical extends Component {
           >
             {outcomes.length > 0 &&
               outcomes.map(outcome => (
-                <CategoricalOutcome key={outcome.id} outcome={outcome} isMobileSmall={isMobileSmall} />
+                <CategoricalOutcome
+                  key={outcome.id}
+                  outcome={outcome}
+                  isMobileSmall={isMobileSmall}
+                />
               ))}
           </div>
         </div>
@@ -117,17 +117,17 @@ class MarketOutcomesCategorical extends Component {
 
 MarketOutcomesCategorical.propTypes = {
   outcomes: PropTypes.array.isRequired,
-  isMobileSmall: PropTypes.bool,
+  isMobileSmall: PropTypes.bool
 };
 
 CategoricalOutcome.propTypes = {
   outcome: PropTypes.object.isRequired,
   className: PropTypes.string,
-  isMobileSmall: PropTypes.bool,
+  isMobileSmall: PropTypes.bool
 };
 
 CategoricalOutcome.defaultProps = {
-  className: null,
+  className: null
 };
 
 export default MarketOutcomesCategorical;

--- a/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.jsx
+++ b/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.jsx
@@ -61,10 +61,12 @@ class MarketOutcomesCategorical extends Component {
     const { outcomes } = this.props;
     const totalOutcomes = outcomes.length;
 
-    const displayShowMore = totalOutcomes > 3;
+    const nums = window.outerWidth >= 590 ? 3 : 6
+
+    const displayShowMore = totalOutcomes > nums;
     const showMoreText = this.state.isOpen
-      ? `- ${totalOutcomes - 3} less`
-      : `+ ${totalOutcomes - 3} more`;
+      ? `- ${totalOutcomes - nums} less`
+      : `+ ${totalOutcomes - nums} more`;
 
     const outcomeWrapperStyle = {
       minHeight: this.state.outcomeWrapperHeight

--- a/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.jsx
+++ b/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.jsx
@@ -6,9 +6,7 @@ import getValue from "utils/get-value";
 import MarketOutcomeTradingIndicator from "modules/market/containers/market-outcome-trading-indicator";
 import Styles from "modules/market/components/market-outcomes-categorical/market-outcomes-categorical.styles";
 
-const fontSize = winWidth => (winWidth < 590 ? "0.875rem" : "1.25rem");
-
-const CategoricalOutcome = ({ className, outcome }) => (
+const CategoricalOutcome = ({ className, outcome, isMobileSmall }) => (
   <div
     className={className || Styles.MarketOutcomesCategorical__outcome}
     style={{
@@ -19,13 +17,11 @@ const CategoricalOutcome = ({ className, outcome }) => (
   >
     <span
       className={Styles["MarketOutcomesCategorical__outcome-name"]}
-      style={{ fontSize: fontSize(window.outerWidth) }}
     >
-      {window.outerWidth >= 590 ? outcome.name : outcome.name[0] + "... "}
+      {isMobileSmall ? outcome.name[0] + "... " : outcome.name}
     </span>
     <span
       className={Styles["MarketOutcomesCategorical__outcome-value"]}
-      style={{ fontSize: fontSize(window.outerWidth) }}
     >
       {getValue(outcome, "lastPricePercent.full")}
     </span>
@@ -58,19 +54,21 @@ class MarketOutcomesCategorical extends Component {
   }
 
   render() {
-    const { outcomes } = this.props;
+    const { outcomes, isMobileSmall } = this.props;
     const totalOutcomes = outcomes.length;
 
-    const nums = window.outerWidth >= 590 ? 3 : 6
-
-    const displayShowMore = totalOutcomes > nums;
+    const numOutcomesToShow = !isMobileSmall ? 3 : 6
+    
+    const displayShowMore = totalOutcomes > numOutcomesToShow;
     const showMoreText = this.state.isOpen
-      ? `- ${totalOutcomes - nums} less`
-      : `+ ${totalOutcomes - nums} more`;
+      ? `- ${totalOutcomes - numOutcomesToShow} less`
+      : `+ ${totalOutcomes - numOutcomesToShow} more`;
 
     const outcomeWrapperStyle = {
       minHeight: this.state.outcomeWrapperHeight
     };
+
+    console.log(isMobileSmall)
 
     return (
       <div
@@ -81,6 +79,7 @@ class MarketOutcomesCategorical extends Component {
           <CategoricalOutcome
             className={Styles["MarketOutcomesCategorical__height-sentinel"]}
             outcome={outcomes[0]}
+            isMobileSmall={isMobileSmall}
           />
         )}
         <div
@@ -107,7 +106,7 @@ class MarketOutcomesCategorical extends Component {
           >
             {outcomes.length > 0 &&
               outcomes.map(outcome => (
-                <CategoricalOutcome key={outcome.id} outcome={outcome} />
+                <CategoricalOutcome key={outcome.id} outcome={outcome} isMobileSmall={isMobileSmall} />
               ))}
           </div>
         </div>
@@ -117,16 +116,18 @@ class MarketOutcomesCategorical extends Component {
 }
 
 MarketOutcomesCategorical.propTypes = {
-  outcomes: PropTypes.array.isRequired
+  outcomes: PropTypes.array.isRequired,
+  isMobileSmall: PropTypes.bool,
 };
 
 CategoricalOutcome.propTypes = {
   outcome: PropTypes.object.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  isMobileSmall: PropTypes.bool,
 };
 
 CategoricalOutcome.defaultProps = {
-  className: null
+  className: null,
 };
 
 export default MarketOutcomesCategorical;

--- a/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.styles.less
+++ b/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.styles.less
@@ -46,7 +46,7 @@
   white-space: nowrap;
 
   @media @breakpoint-mobile-small {
-    font-size: 0.875rem; 
+    font-size: 0.875rem;
   }
 }
 
@@ -57,7 +57,7 @@
   position: relative;
 
   @media @breakpoint-mobile-small {
-    font-size: 0.875rem; 
+    font-size: 0.875rem;
   }
 }
 

--- a/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.styles.less
+++ b/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.styles.less
@@ -44,6 +44,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @media @breakpoint-mobile-small {
+    font-size: 0.875rem; 
+  }
 }
 
 .MarketOutcomesCategorical__outcome-value {
@@ -51,6 +55,10 @@
 
   margin-left: 1.75rem;
   position: relative;
+
+  @media @breakpoint-mobile-small {
+    font-size: 0.875rem; 
+  }
 }
 
 .MarketOutcomesCategorical__show-more {

--- a/src/modules/market/containers/market-basics.js
+++ b/src/modules/market/containers/market-basics.js
@@ -7,7 +7,7 @@ import { selectCurrentTimestamp } from "src/select-state";
 const mapStateToProps = state => ({
   currentTimestamp: selectCurrentTimestamp(state),
   isMobile: state.appStatus.isMobile,
-  isMobileSmall: state.appStatus.isMobileSmall,
+  isMobileSmall: state.appStatus.isMobileSmall
 });
 
 const MarketBasicsContainer = connect(mapStateToProps)(MarketBasics);

--- a/src/modules/market/containers/market-basics.js
+++ b/src/modules/market/containers/market-basics.js
@@ -6,7 +6,8 @@ import { selectCurrentTimestamp } from "src/select-state";
 
 const mapStateToProps = state => ({
   currentTimestamp: selectCurrentTimestamp(state),
-  isMobile: state.appStatus.isMobile
+  isMobile: state.appStatus.isMobile,
+  isMobileSmall: state.appStatus.isMobileSmall,
 });
 
 const MarketBasicsContainer = connect(mapStateToProps)(MarketBasics);


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17544/categorical-market-card-outcomes-expand-and-de-expand-is-messed-up-on-mobile-don-t-need-to-be-logged-in-to-see-this

- show 6 outcomes instead of 3 for categorical on small screens (already done before, but updated code so no bug with it)
- updated code to use isMobileSmall and css mobile breakpoints 
