### PR TITLE
update styles for mobile side nav

### DIFF
--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -33,7 +33,7 @@ import NavAccountIcon from "modules/common/components/nav-account-icon";
 import NavCreateIcon from "modules/common/components/nav-create-icon";
 import NavMarketsIcon from "modules/common/components/nav-markets-icon";
 import NavPortfolioIcon from "modules/common/components/nav-portfolio-icon";
-import { AlertCircle, NavReportingIcon } from "modules/common/components/icons";
+import { NavReportingIcon } from "modules/common/components/icons";
 
 import parsePath from "modules/routes/helpers/parse-path";
 import makePath from "modules/routes/helpers/make-path";
@@ -463,9 +463,6 @@ export default class AppView extends Component {
         onClick={() => this.mobileMenuButtonClick()}
       >
         {icon}
-        {menuState === mobileMenuStates.CLOSED &&
-          !!unseenCount &&
-          AlertCircle(Styles["SideBar__mobile-bars-unseen"])}
       </button>
     );
   }
@@ -544,8 +541,6 @@ export default class AppView extends Component {
               mobileShow={s.mobileMenuState === mobileMenuStates.SIDEBAR_OPEN}
               menuScalar={subMenu.scalar}
               menuData={this.sideNavMenuData}
-              unseenCount={unseenCount}
-              toggleNotifications={this.toggleNotifications}
               stats={coreStats}
               currentBasePath={this.state.currentBasePath}
             />

--- a/src/modules/app/components/gas-price-edit/gas-price-edit.jsx
+++ b/src/modules/app/components/gas-price-edit/gas-price-edit.jsx
@@ -42,7 +42,9 @@ export default class GasPriceEdit extends Component {
           role="button"
           tabIndex="-1"
         >
-          <div className={Styles.GasPriceEdit__title}>GAS PRICE (GWEI)</div>
+          <div className={Styles.GasPriceEdit__title}>
+            GAS PRICE <span className={Styles.GasPriceEdit__unit}>(GWEI)</span>
+          </div>
           <div className={Styles.GasPriceEdit__info}>
             <div className={Styles.GasPriceEdit__price}>
               {userDefinedGasPrice}

--- a/src/modules/app/components/gas-price-edit/gas-price-edit.styles.less
+++ b/src/modules/app/components/gas-price-edit/gas-price-edit.styles.less
@@ -12,10 +12,6 @@
   &:hover {
     background-color: @color-lightpurple;
   }
-
-  @media @breakpoint-mobile-mid {
-    max-width: unset;
-  }
 }
 
 .GasPriceEdit__container {
@@ -76,4 +72,30 @@
   color: @color-lightergray;
   font-size: 10px;
   text-decoration: underline;
+}
+
+@media @breakpoint-mobile-mid {
+  .GasPriceEdit {
+    max-width: unset;
+  }
+
+  .GasPriceEdit__container {
+    flex-direction: row;
+    padding: 16px 24px;
+  }
+
+  .GasPriceEdit__unit {
+    display: none;
+  }
+
+  .GasPriceEdit__info {
+    align-items: center;
+    display: flex;
+    flex-grow: 1;
+    justify-content: flex-end;
+  }
+
+  .GasPriceEdit__price {
+    max-width: 40px;
+  }
 }

--- a/src/modules/app/components/side-nav/side-nav.jsx
+++ b/src/modules/app/components/side-nav/side-nav.jsx
@@ -17,8 +17,6 @@ export default class SideNav extends Component {
     isLogged: PropTypes.bool.isRequired,
     menuData: PropTypes.array.isRequired,
     mobileShow: PropTypes.bool.isRequired,
-    toggleNotifications: PropTypes.func.isRequired,
-    unseenCount: PropTypes.number.isRequired,
     stats: PropTypes.array.isRequired,
     currentBasePath: PropTypes.string.isRequired
   };
@@ -144,6 +142,7 @@ export default class SideNav extends Component {
                   {stats[1].totalPLMonth.label}
                   <span className={Styles["SideNav__stat-value"]}>
                     {stats[1].totalPLMonth.value.formatted}
+                    <span className={Styles["SideNav__stat-unit"]}>ETH</span>
                   </span>
                 </div>
                 <div
@@ -153,6 +152,7 @@ export default class SideNav extends Component {
                   {stats[1].totalPLDay.label}
                   <span className={Styles["SideNav__stat-value"]}>
                     {stats[1].totalPLDay.value.formatted}
+                    <span className={Styles["SideNav__stat-unit"]}>ETH</span>
                   </span>
                 </div>
               </div>

--- a/src/modules/app/components/side-nav/side-nav.styles.less
+++ b/src/modules/app/components/side-nav/side-nav.styles.less
@@ -122,8 +122,11 @@
   }
 
   .SideNav__stat-label {
-    color: @color-white;
-    font-weight: 500;
+    color: @color-lightergray;
+    display: flex;
+    flex-direction: row;
+    font-size: @font-size-extra-small;
+    font-weight: 400;
     max-width: 100%;
     overflow: hidden;
     padding-bottom: 0.5rem;
@@ -132,12 +135,24 @@
 
   .SideNav__stat-value {
     color: @color-white;
-    font-weight: 400;
-    padding-left: 0.5rem;
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+    font-size: @font-size-medium;
+    font-weight: 700;
+    justify-content: flex-end;
   }
 
   .SideName__placement {
-    padding: 1.5rem;
+    padding: 16px 24px;
+  }
+
+  .SideNav__stat-unit {
+    align-items: flex-end;
+    display: flex;
+    font-size: @font-size-extra-small;
+    margin-bottom: 2px;
+    margin-left: 0.25rem;
   }
 
   .SideNav__amt {

--- a/src/modules/common/components/nav-logout-icon.jsx
+++ b/src/modules/common/components/nav-logout-icon.jsx
@@ -9,6 +9,7 @@ const NavLogoutIcon = ({ className }) => (
     height="16"
     viewBox="0 0 18 18"
     className={classNames("nav-logout-icon", { [className]: className })}
+    style={{ marginLeft: ".28rem", width: "1.2rem" }}
   >
     <g fill="#FFF" fillRule="nonzero">
       <path d="M14.16 10.123H5.624a1.125 1.125 0 0 1 0-2.25h8.534l-1.454-1.455a1.125 1.125 0 0 1 1.59-1.59l3.375 3.374a1.125 1.125 0 0 1 0 1.591l-3.375 3.375a1.125 1.125 0 1 1-1.59-1.59l1.454-1.455z" />

--- a/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.jsx
+++ b/src/modules/market/components/market-outcomes-categorical/market-outcomes-categorical.jsx
@@ -117,7 +117,7 @@ class MarketOutcomesCategorical extends Component {
 
 MarketOutcomesCategorical.propTypes = {
   outcomes: PropTypes.array.isRequired,
-  isMobileSmall: PropTypes.bool
+  isMobileSmall: PropTypes.bool.isRequired
 };
 
 CategoricalOutcome.propTypes = {
@@ -127,7 +127,8 @@ CategoricalOutcome.propTypes = {
 };
 
 CategoricalOutcome.defaultProps = {
-  className: null
+  className: null,
+  isMobileSmall: false
 };
 
 export default MarketOutcomesCategorical;


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17588/mobile-header-text-on-categories-page-are-cut-off-when-logged-in
<img width="414" alt="screen shot 2018-10-24 at 9 07 07 am" src="https://user-images.githubusercontent.com/6775839/47445001-a9340a80-d76c-11e8-81cf-8329d79233c9.png">
