### PR TITLE
johndanz/ch17746/error-when-gas-price-form

### DIFF
--- a/src/modules/modal/components/modal-gas-price.jsx
+++ b/src/modules/modal/components/modal-gas-price.jsx
@@ -15,7 +15,11 @@ export default class ModalGasPrice extends Component {
     safeLow: PropTypes.number.isRequired,
     average: PropTypes.number.isRequired,
     fast: PropTypes.number.isRequired,
-    userDefinedGasPrice: PropTypes.number.isRequired
+    userDefinedGasPrice: PropTypes.number
+  };
+
+  static defaultProps = {
+    userDefinedGasPrice: null
   };
 
   constructor(props) {


### PR DESCRIPTION
defaulted userDefinedGasPrice to null, no longer Required. will default to average gas price if user price is null