### PR TITLE
make tooltips clickable, add fee tooltip

### DIFF
--- a/src/modules/common/less/tooltip.less
+++ b/src/modules/common/less/tooltip.less
@@ -11,6 +11,7 @@
   line-height: 0.9375rem;
   max-width: 13.7rem;
   padding: 1rem 1.5rem !important;
+  pointer-events: auto !important;
   text-transform: none;
   white-space: initial;
 
@@ -25,6 +26,11 @@
     &:last-child {
       margin-bottom: 0;
     }
+  }
+
+  &:hover {
+    opacity: 1 !important;
+    visibility: visible !important;
   }
 }
 

--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -95,7 +95,7 @@ const MarketProperties = ({
             />
           </li>
           <li>
-            <span>Fee</span>
+            <span>Est. Fee</span>
             <ValueDenomination valueClassname="fee" {...settlementFeePercent} />
           </li>
           <li>

--- a/src/modules/trading/components/trading--confirm/trading--confirm.jsx
+++ b/src/modules/trading/components/trading--confirm/trading--confirm.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { CreateMarketEdit } from "modules/common/components/icons";
-
 import ValueDenomination from "modules/common/components/value-denomination/value-denomination";
 import classNames from "classnames";
 import { CATEGORICAL } from "modules/markets/constants/market-types";
 import { MARKET, BUY, LIMIT, SELL } from "modules/transactions/constants/types";
-
+import ReactTooltip from "react-tooltip";
+import TooltipStyles from "modules/common/less/tooltip";
+import { CreateMarketEdit, Hint } from "modules/common/components/icons";
 import Styles from "modules/trading/components/trading--confirm/trading--confirm.styles";
 
 const MarketTradingConfirm = ({
@@ -92,7 +92,39 @@ const MarketTradingConfirm = ({
           </li>
         )}
         <li>
-          <span>Fee</span>
+          <span className={Styles.TradingConfirm__FeeLabel}>Est. Fee</span>
+          <span className={Styles.TradingConfirm__TooltipContainer}>
+            <label
+              className={classNames(
+                TooltipStyles.TooltipHint,
+                Styles.TradingConfirm__TooltipHint
+              )}
+              data-tip
+              data-for="tooltip--fee"
+            >
+              {Hint}
+            </label>
+            <ReactTooltip
+              id="tooltip--fee"
+              className={TooltipStyles.Tooltip}
+              effect="solid"
+              place="bottom"
+              type="light"
+            >
+              <p>
+                The reporting fee adjusts every week, which may cause the
+                market‘s total fee to go up or down.
+              </p>
+              <a
+                href="http://docs.augur.net/#reporting-fee"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                {" "}
+                Lean more here.
+              </a>
+            </ReactTooltip>
+          </span>
           <span>
             {tradingFees ? tradingFees.formattedValue : "0"} <span>ETH</span>
           </span>

--- a/src/modules/trading/components/trading--confirm/trading--confirm.styles.less
+++ b/src/modules/trading/components/trading--confirm/trading--confirm.styles.less
@@ -137,6 +137,20 @@
   }
 }
 
+.TradingConfirm__FeeLabel {
+  margin-right: 0.5rem !important;
+  width: unset !important;
+}
+
+.TradingConfirm__TooltipHint {
+  margin-bottom: 0;
+  width: 0.9rem;
+}
+
+.TradingConfirm__TooltipContainer {
+  width: 5rem;
+}
+
 @media @breakpoint-mobile {
   .TradingConfirmation__actions {
     min-height: 6.25rem;


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17616/add-tooltip-when-confirming-a-trade-allow-tooltips-to-be-clickable