### PR TITLE
Add confirmed notification for market creator fees

### DIFF
--- a/src/modules/market/components/market-preview/market-preview.jsx
+++ b/src/modules/market/components/market-preview/market-preview.jsx
@@ -34,7 +34,7 @@ export default class MarketPreview extends Component {
     hideReportEndingIndicator: PropTypes.bool,
     linkType: PropTypes.string,
     collectMarketCreatorFees: PropTypes.func.isRequired,
-    hideOutstandingReturns: PropTypes.bool
+    showOutstandingReturns: PropTypes.bool
   };
 
   static defaultProps = {
@@ -50,7 +50,7 @@ export default class MarketPreview extends Component {
     testid: null,
     outcomes: [],
     settlementFeePercent: null,
-    hideOutstandingReturns: false
+    showOutstandingReturns: false
   };
 
   constructor(props) {
@@ -95,7 +95,7 @@ export default class MarketPreview extends Component {
             />
           </div>
           {p.unclaimedCreatorFees.value > 0 &&
-            !p.hideOutstandingReturns && (
+            p.showOutstandingReturns && (
               <div
                 className={classNames(Styles.MarketPreview__returns, {
                   [`${Styles["single-card"]}`]: p.cardStyle === "single-card"

--- a/src/modules/markets-list/components/markets-list.jsx
+++ b/src/modules/markets-list/components/markets-list.jsx
@@ -31,7 +31,7 @@ export default class MarketsList extends Component {
     style: PropTypes.object,
     showDisputingCard: PropTypes.bool,
     outcomes: PropTypes.object,
-    hideOutstandingReturns: PropTypes.bool
+    showOutstandingReturns: PropTypes.bool
   };
 
   static defaultProps = {
@@ -44,7 +44,7 @@ export default class MarketsList extends Component {
     style: null,
     showDisputingCard: false,
     outcomes: null,
-    hideOutstandingReturns: false
+    showOutstandingReturns: false
   };
 
   constructor(props) {
@@ -134,7 +134,7 @@ export default class MarketsList extends Component {
       showDisputingCard,
       outcomes,
       linkType,
-      hideOutstandingReturns
+      showOutstandingReturns
     } = this.props;
     const s = this.state;
 
@@ -174,7 +174,7 @@ export default class MarketsList extends Component {
                   id={market.id}
                   testid={testid}
                   pendingLiquidityOrders={pendingLiquidityOrders}
-                  hideOutstandingReturns={hideOutstandingReturns}
+                  showOutstandingReturns={showOutstandingReturns}
                 />
               );
             }

--- a/src/modules/markets/actions/market-creator-fees-management.js
+++ b/src/modules/markets/actions/market-creator-fees-management.js
@@ -5,6 +5,8 @@ import speedomatic from "speedomatic";
 import { augur } from "services/augurjs";
 import { loadMarketsInfo } from "modules/markets/actions/load-markets-info";
 import { updateMarketsData } from "modules/markets/actions/update-markets-data";
+import { selectCurrentTimestampInSeconds } from "src/select-state";
+import { updateNotification } from "modules/notifications/actions/notifications";
 
 export const UPDATE_MARKET_CREATOR_FEES = "UPDATE_MARKET_CREATOR_FEES";
 
@@ -92,6 +94,13 @@ export const collectMarketCreatorFees = (
                     dispatch(loadMarketsInfo([marketId]));
                     dispatch(loadUnclaimedFees([marketId]));
                     callback(null, combined);
+                    dispatch(
+                      updateNotification(res.hash, {
+                        id: res.hash,
+                        status: "Confirmed",
+                        timestamp: selectCurrentTimestampInSeconds(getState())
+                      })
+                    );
                   },
                   onFailed: err => callback(err)
                 });

--- a/src/modules/portfolio/components/markets/markets.jsx
+++ b/src/modules/portfolio/components/markets/markets.jsx
@@ -179,6 +179,7 @@ class MyMarkets extends Component {
             loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
             isMobile={isMobile}
             pendingLiquidityOrders={pendingLiquidityOrders}
+            showOutstandingReturns
           />
         )}
         {haveMarkets && <MarketsHeaderLabel title="In Reporting" />}
@@ -197,6 +198,7 @@ class MyMarkets extends Component {
             collectMarketCreatorFees={collectMarketCreatorFees}
             loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
             isMobile={isMobile}
+            showOutstandingReturns
           />
         )}
         {haveMarkets && <MarketsHeaderLabel title="In Dispute" />}
@@ -217,6 +219,7 @@ class MyMarkets extends Component {
             isMobile={isMobile}
             showDisputingCard
             outcomes={outcomes}
+            showOutstandingReturns
           />
         )}
         {haveMarkets && <MarketsHeaderLabel title="Resolved" />}
@@ -236,6 +239,7 @@ class MyMarkets extends Component {
             loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
             isMobile={isMobile}
             addNullPadding
+            showOutstandingReturns
           />
         )}
         {(myMarkets == null || (myMarkets && myMarkets.length === 0)) && (

--- a/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
+++ b/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
@@ -208,7 +208,6 @@ export default class PortfolioReports extends Component {
             noShowHeader
             toggleFavorite={toggleFavorite}
             nullMessage="Markets you have staked on will be listed here when resolved."
-            hideOutstandingReturns
           />
         </div>
       </div>

--- a/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
+++ b/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
@@ -36,7 +36,7 @@ export default class ReportingResolved extends Component {
     forkingMarket: PropTypes.object,
     loadReporting: PropTypes.func,
     isMobile: PropTypes.bool.isRequired,
-    hideOutstandingReturns: PropTypes.bool
+    showOutstandingReturns: PropTypes.bool
   };
 
   static defaultProps = {
@@ -45,7 +45,7 @@ export default class ReportingResolved extends Component {
     noShowHeader: false,
     forkingMarket: null,
     loadReporting: null,
-    hideOutstandingReturns: false
+    showOutstandingReturns: false
   };
 
   constructor(props) {
@@ -82,7 +82,7 @@ export default class ReportingResolved extends Component {
       nullMessage,
       location,
       history,
-      hideOutstandingReturns
+      showOutstandingReturns
     } = this.props;
     const s = this.state;
 
@@ -119,7 +119,7 @@ export default class ReportingResolved extends Component {
           paginationPageParam="reporting-resolved-page"
           nullMessage={nullMessage}
           addNullPadding
-          hideOutstandingReturns={hideOutstandingReturns}
+          showOutstandingReturns={showOutstandingReturns}
         />
       </section>
     );

--- a/test/markets/actions/collect-market-creator-fees-test.js
+++ b/test/markets/actions/collect-market-creator-fees-test.js
@@ -20,7 +20,8 @@ describe("modules/markets/actions/market-creator-fees-management.js", () => {
 
     const ACTIONS = {
       UPDATE_MARKETS_DATA: "UPDATE_MARKETS_DATA",
-      UPDATE_UNCLAIMED_DATA: "UPDATE_UNCLAIMED_DATA"
+      UPDATE_UNCLAIMED_DATA: "UPDATE_UNCLAIMED_DATA",
+      UPDATE_NOTIFICATION: "UPDATE_NOTIFICATION"
     };
     const MailboxAddresses = ["0xmailbox01", "0xmailbox02"];
     const MarketIds = ["0xmyMarket01", "0xmyMarket02"];
@@ -83,7 +84,7 @@ describe("modules/markets/actions/market-creator-fees-management.js", () => {
               p.onFailed,
               `onFailed provided to withdrawEther isn't a function.`
             );
-            p.onSuccess();
+            p.onSuccess({ hash: "0xtest" });
           }
         }
       },
@@ -118,12 +119,23 @@ describe("modules/markets/actions/market-creator-fees-management.js", () => {
         marketId
       }
     }));
+    __RewireAPI__.__Rewire__("updateNotification", hash => ({
+      type: ACTIONS.UPDATE_NOTIFICATION,
+      data: {
+        hash: "0xtest"
+      }
+    }));
+
+
 
     test({
       description: `Should fire a withdrawEther and updateMarketsData if we have ETH to collect from a market.`,
       state: {
         loginAccount: {
           address: "ADDRESS"
+        },
+        blockchain: {
+          currentAugurTimestamp: 1521665
         }
       },
       assertions: store => {
@@ -155,6 +167,12 @@ describe("modules/markets/actions/market-creator-fees-management.js", () => {
             type: ACTIONS.UPDATE_UNCLAIMED_DATA,
             data: {
               marketId: [MarketIds[0]]
+            }
+          },
+          {
+            type: ACTIONS.UPDATE_NOTIFICATION,
+            data: {
+              hash: "0xtest"
             }
           }
         ];


### PR DESCRIPTION
- fixed "withdrawing eth"/ claiming market creator return notifications being stuck in pending
- changed market-outstanding-returns to only show in /my-markets (the claiming for positions is a different component)

<img width="445" alt="screen shot 2018-10-30 at 4 14 45 pm" src="https://user-images.githubusercontent.com/6775839/47757415-7e155380-dc63-11e8-8467-d3eb57320ee8.png">
