### PR TITLE
add rounding to open interest

### DIFF
--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -90,8 +90,7 @@ const MarketProperties = ({
             <span>Open Interest</span>
             <ValueDenomination
               valueClassname="volume"
-              formatted={openInterest}
-              denomination="ETH"
+              formatted={openInterest.full}
             />
           </li>
           <li>

--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -90,7 +90,7 @@ const MarketProperties = ({
             <span>Open Interest</span>
             <ValueDenomination
               valueClassname="volume"
-              formatted={openInterest.full}
+              formatted={openInterest.formatted}
             />
           </li>
           <li>
@@ -238,7 +238,7 @@ MarketProperties.propTypes = {
   forkingMarket: PropTypes.string,
   resolutionSource: PropTypes.string,
   marketType: PropTypes.string,
-  openInterest: PropTypes.string,
+  openInterest: PropTypes.object,
   volume: PropTypes.object,
   loginAccount: PropTypes.object,
   reportingState: PropTypes.string,

--- a/src/modules/markets/selectors/market.js
+++ b/src/modules/markets/selectors/market.js
@@ -256,6 +256,9 @@ export function assembleMarket(
           marketData.settlementFee * 100,
           { positiveSign: false, decimals: 4, decimalsRounded: 4 }
         );
+        market.openInterest = formatEther(marketData.openInterest, {
+          positiveSign: false
+        });
         market.volume = formatEther(marketData.volume, {
           positiveSign: false
         });

--- a/test/assertions/market.js
+++ b/test/assertions/market.js
@@ -62,6 +62,11 @@ export default function(market) {
       );
     });
 
+    it("market.openInterest", () => {
+      assert.isDefined(market.openInterest);
+      assertFormattedNumber(market.openInterest, "market.openInterest");
+    });
+
     it("market.volume", () => {
       assert.isDefined(market.volume);
       assertFormattedNumber(market.volume, "market.volume");


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17558/open-interest-on-market-cards-needs-formatting-rounding