### PR TITLE
remove limit

### DIFF
--- a/src/modules/markets/actions/market-trading-history-management.js
+++ b/src/modules/markets/actions/market-trading-history-management.js
@@ -19,7 +19,7 @@ export const loadMarketTradingHistory = (options, callback = logError) => (
 ) => {
   if (options === null || !options.marketId) return callback(null);
   const allOptions = Object.assign(
-    { limit: 10, sortBy: "timestamp", isSortDescending: true },
+    { sortBy: "timestamp", isSortDescending: true },
     options
   );
   augur.augurNode.submitRequest(


### PR DESCRIPTION
https://app.clubhouse.io/augur/story/17820/direction-trade-arrow-in-last-field-not-displayed-on-trading-page

to repro the bug on master:
1. trade on a categorical market 10 times
2. the 11th time on a new outcome that has never been traded on will not have an arrow