### PR TITLE
Scrolling through markets stops abruptly

### DIFF
--- a/src/modules/app/components/app/app.styles.less
+++ b/src/modules/app/components/app/app.styles.less
@@ -80,6 +80,7 @@ h6 {
 
 .Main__content {
   height: calc(~"100vh - @{top-bar-height}");
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   overflow-y: auto;
 

--- a/src/modules/modal/components/common/common.styles.less
+++ b/src/modules/modal/components/common/common.styles.less
@@ -443,6 +443,7 @@ div.ErrorField:focus {
   max-height: 25rem;
   max-width: 35rem;
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
   padding: 0.5rem 2rem;
   text-align: left;
   width: auto;
@@ -516,6 +517,10 @@ div.ErrorField:focus {
 @media @breakpoint-mobile-small {
   .ModalView__content {
     padding: 1rem;
+  }
+
+  .ModalView__content--taller {
+    justify-content: flex-start;
   }
 
   .ModalContainer > p,

--- a/src/modules/modal/components/modal-view.jsx
+++ b/src/modules/modal/components/modal-view.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 
 import ModalSignTransaction from "modules/modal/containers/modal-sign-transaction";
 import ModalConfirm from "modules/modal/components/modal-confirm";
@@ -38,7 +39,12 @@ export default class ModalView extends Component {
 
     return (
       <section className={Styles.ModalView}>
-        <div className={Styles.ModalView__content}>
+        <div
+          className={classNames(Styles.ModalView__content, {
+            [`${Styles["ModalView__content--taller"]}`]:
+              modal.type === TYPES.MODAL_DISCLAIMER
+          })}
+        >
           {modal.type === TYPES.MODAL_CLAIM_TRADING_PROCEEDS && (
             <ModalClaimTradingProceeds {...this.props} />
           )}


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/17593

tested using xcode simulator. if you compare to dev or master, you can see it doesn't do the quick scrolling but on this branch it does. 

also fixed up the disclaimer pop up a bit.
https://app.clubhouse.io/augur/story/17916/hard-to-click-agree-button-on-mobile