### PR TITLE
create market time picker doesn't work in mobile

### DIFF
--- a/src/modules/common/components/input-dropdown/input-dropdown.jsx
+++ b/src/modules/common/components/input-dropdown/input-dropdown.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */ // needed for mobile safari
+
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
@@ -80,8 +82,6 @@ class InputDropdown extends Component {
         }}
         className={classNames(Styles.InputDropdown, className)}
         onClick={this.toggleList}
-        role="listbox"
-        tabIndex="-1"
         onKeyPress={value => this.onKeyPress(value)}
       >
         <span


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/17834

Noticed all InputDropdown components did not work in mobile safari. Role and tab-index were causing problems so took that out. 

Account-withdraw, create market time picker, and categorical market outcome picker for initial liquidity all use it. 

Can test on xcode ios simulator and by logging in using Edge. You can also kind of see it being awkward to use in chrome iPhone simulator. 