### PR TITLE
clicking on markets before having been on positions page and positions hasnt finished loading keeps position tabs around

### DIFF
--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -285,7 +285,7 @@ export default class AppView extends Component {
 
   changeMenu(nextBasePath) {
     const { isLogged } = this.props;
-    const oldType = this.state.currentInnerNavType;
+    const oldType = navTypes[this.state.currentBasePath]
     const newType = navTypes[nextBasePath];
 
     if ((newType === AccountInnerNav && !isLogged) || oldType === newType) {

--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -285,7 +285,7 @@ export default class AppView extends Component {
 
   changeMenu(nextBasePath) {
     const { isLogged } = this.props;
-    const oldType = navTypes[this.state.currentBasePath]
+    const oldType = navTypes[this.state.currentBasePath];
     const newType = navTypes[nextBasePath];
 
     if ((newType === AccountInnerNav && !isLogged) || oldType === newType) {


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/17004

repro:

click on markets
click on portfolio
before portfolio sub menu has time to come out, click on markets
(works with reporting tab instead of markets, as well)

issue was the nav type doesn't get set when you click off quickly and so you are just comparing it to the previous one.