### PR TITLE
position on mobile trade page is missing price

### DIFF
--- a/src/modules/market/components/market-positions-list--mobile-positions/market-positions-list--mobile-positions.jsx
+++ b/src/modules/market/components/market-positions-list--mobile-positions/market-positions-list--mobile-positions.jsx
@@ -100,7 +100,7 @@ export default class MobilePositions extends Component {
                   </span>
                 )}
               </span>
-              {getValue(position, "avgPrice.formatted")} ETH
+              {getValue(position, "purchasePrice.formatted")} ETH
             </li>
             <li>
               <span>Unrealized P/L</span>


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/18008

<img width="556" alt="screen shot 2018-11-08 at 1 35 15 pm" src="https://user-images.githubusercontent.com/6775839/48228828-265da300-e35b-11e8-82ad-ab89e35e0e01.png">
