### PR TITLE
refactor button layouts for mobile, add padding so they are more clickable to mobile

### DIFF
--- a/src/modules/app/components/app/app.styles.less
+++ b/src/modules/app/components/app/app.styles.less
@@ -101,13 +101,13 @@ h6 {
   background: none;
   border: none;
   display: none;
-  height: 36px;
-  left: 6px;
+  height: 2.25rem;
+  left: 0.375rem;
   outline: none;
-  padding: 10px;
+  padding: 0.625rem;
   position: absolute;
-  top: 6px;
-  width: 36px;
+  top: 0.375rem;
+  width: 2.25rem;
   z-index: @mask-above;
 
   svg {

--- a/src/modules/app/components/app/app.styles.less
+++ b/src/modules/app/components/app/app.styles.less
@@ -101,13 +101,13 @@ h6 {
   background: none;
   border: none;
   display: none;
-  height: 16px;
-  left: 16px;
+  height: 36px;
+  left: 6px;
   outline: none;
-  padding: 0;
+  padding: 10px;
   position: absolute;
-  top: 16px;
-  width: 16px;
+  top: 6px;
+  width: 36px;
   z-index: @mask-above;
 
   svg {

--- a/src/modules/app/components/top-bar/top-bar.styles.less
+++ b/src/modules/app/components/top-bar/top-bar.styles.less
@@ -62,11 +62,15 @@ div.TopBar__notifications {
   }
 }
 
-.TopBar__notificationsDisabled {
+div.TopBar__notificationsDisabled {
   cursor: default;
 
   &:hover {
     background-color: @color-purple;
+  }
+
+  @media @breakpoint-mobile-extra-small {
+    display: none;
   }
 }
 
@@ -90,6 +94,10 @@ div.TopBar__notifications {
   justify-content: center;
   margin-right: 2rem;
   width: 1.25rem;
+
+  @media @breakpoint-mobile-extra-small {
+    margin-right: 1rem;
+  }
 }
 
 .TopBar__stat-label {

--- a/src/modules/auth/components/connect-account/connect-account.styles.less
+++ b/src/modules/auth/components/connect-account/connect-account.styles.less
@@ -14,7 +14,7 @@
   }
 
   @media @breakpoint-mobile-extra-small {
-    max-width: 200px;
+    max-width: 12.5rem;
   }
 }
 

--- a/src/modules/auth/components/connect-account/connect-account.styles.less
+++ b/src/modules/auth/components/connect-account/connect-account.styles.less
@@ -12,6 +12,10 @@
   &:hover {
     background-color: @color-lightpurple;
   }
+
+  @media @breakpoint-mobile-extra-small {
+    max-width: 200px;
+  }
 }
 
 .ConnectAccountLoggedIn {
@@ -108,5 +112,9 @@
 
   @media @breakpoint-mobile {
     top: 3.1rem;
+  }
+
+  @media @breakpoint-mobile-extra-small {
+    right: 0;
   }
 }


### PR DESCRIPTION
Story details: https://app.clubhouse.io/augur/story/17604

- give side bar button some padding
- ui improvements for iphone 5/se: hide logged out notification icon cause it pushed login dropdown to side of screen, notification icon needs even padding around it, incr max width on the label 