### PR TITLE
Tomhaile/ch17799/scan ledger trezor for addresses with eth

### DIFF
--- a/src/modules/auth/actions/get-ether-balance.js
+++ b/src/modules/auth/actions/get-ether-balance.js
@@ -11,6 +11,6 @@ export default function getEtherBalance(address, callback) {
   augur.rpc.eth.getBalance([address, "latest"], (err, attoEtherBalance) => {
     if (err) return callback(err);
     const etherBalance = speedomatic.unfix(attoEtherBalance, "string");
-    callback(null, etherBalance);
+    callback(null, etherBalance, address);
   });
 }

--- a/src/modules/auth/components/common/address-picker-content.jsx
+++ b/src/modules/auth/components/common/address-picker-content.jsx
@@ -4,7 +4,6 @@ import classNames from "classnames";
 
 import formatAddress from "modules/auth/helpers/format-address";
 import { prevIcon, nextIcon } from "modules/common/components/icons";
-import getEtherBalance from "modules/auth/actions/get-ether-balance";
 import { formatEther } from "utils/format-number";
 
 import StylesDropdown from "modules/auth/components/connect-dropdown/connect-dropdown.styles";
@@ -25,15 +24,11 @@ export default class AddressPickerContent extends Component {
 
     this.LedgerEthereum = null;
 
-    this.state = {
-      addressBalances: {}
-    };
-
     this.clickPrevious = this.clickPrevious.bind(this);
 
-    props.addresses.map(address => this.updateAccountBalance(address));
+    // props.addresses.map(address => this.updateAccountBalance(address));
   }
-
+  /*
   componentWillUpdate(nextProps, nextState) {
     if (this.props.addresses !== nextProps.addresses) {
       nextProps.addresses.map(address => this.updateAccountBalance(address));
@@ -56,7 +51,7 @@ export default class AddressPickerContent extends Component {
       });
     }
   }
-
+*/
   clickPrevious() {
     if (!this.props.disablePrevious) {
       this.props.clickPrevious();
@@ -71,7 +66,6 @@ export default class AddressPickerContent extends Component {
       clickNext,
       disablePrevious
     } = this.props;
-    const { addressBalances } = this.state;
 
     return (
       <div
@@ -91,23 +85,25 @@ export default class AddressPickerContent extends Component {
             Balance
           </div>
         </div>
-        {indexArray.map(i => (
+        {indexArray.map(index => (
           <div
-            key={i}
+            key={index}
             className={classNames(StylesDropdown.ConnectDropdown__row, {
-              [StylesDropdown.FadeInAndOut]: !addresses[i],
+              [StylesDropdown.FadeInAndOut]: !(addresses[index] || {}).address,
               [StylesDropdown.ConnectDropdown__rowTransition]: true
             })}
           >
             <button
               className={StylesDropdown.ConnectDropdown__addressColumn}
-              onClick={() => clickAction(i)}
+              onClick={() => clickAction(addresses[index])}
             >
-              {(addresses[i] && formatAddress(addresses[i])) || `—`}
+              {((addresses[index] || {}).address &&
+                formatAddress((addresses[index] || {}).address)) ||
+                `—`}
             </button>
             <div className={StylesDropdown.ConnectDropdown__balanceColumn}>
-              {addressBalances[addresses[i]]
-                ? formatEther(addressBalances[addresses[i]]).formatted
+              {(addresses[index] || {}).balance
+                ? formatEther((addresses[index] || {}).balance).formatted
                 : `—`}
             </div>
           </div>

--- a/src/modules/auth/components/common/address-picker-content.jsx
+++ b/src/modules/auth/components/common/address-picker-content.jsx
@@ -16,7 +16,8 @@ export default class AddressPickerContent extends Component {
     clickAction: PropTypes.func.isRequired,
     clickPrevious: PropTypes.func.isRequired,
     clickNext: PropTypes.func.isRequired,
-    disablePrevious: PropTypes.bool.isRequired
+    disablePrevious: PropTypes.bool.isRequired,
+    disableNext: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -25,36 +26,18 @@ export default class AddressPickerContent extends Component {
     this.LedgerEthereum = null;
 
     this.clickPrevious = this.clickPrevious.bind(this);
-
-    // props.addresses.map(address => this.updateAccountBalance(address));
-  }
-  /*
-  componentWillUpdate(nextProps, nextState) {
-    if (this.props.addresses !== nextProps.addresses) {
-      nextProps.addresses.map(address => this.updateAccountBalance(address));
-    }
+    this.clickNext = this.clickNext.bind(this);
   }
 
-  updateAccountBalance(address) {
-    if (!this.state.addressBalances[address] && address) {
-      getEtherBalance(address, (err, balance) => {
-        if (!err) {
-          const balances = {
-            ...this.state.addressBalances
-          };
-          balances[address] = balance || 0;
-
-          this.setState({
-            addressBalances: balances
-          });
-        }
-      });
-    }
-  }
-*/
   clickPrevious() {
     if (!this.props.disablePrevious) {
       this.props.clickPrevious();
+    }
+  }
+
+  clickNext() {
+    if (!this.props.disableNext) {
+      this.props.clickNext();
     }
   }
 
@@ -63,8 +46,8 @@ export default class AddressPickerContent extends Component {
       indexArray,
       addresses,
       clickAction,
-      clickNext,
-      disablePrevious
+      disablePrevious,
+      disableNext
     } = this.props;
 
     return (
@@ -129,8 +112,10 @@ export default class AddressPickerContent extends Component {
             Previous
           </button>
           <button
-            className={Styles.AddressPickerContent__direction}
-            onClick={clickNext}
+            className={classNames(Styles.AddressPickerContent__direction, {
+              [Styles.AddressPickerContent__directionDisabled]: disableNext
+            })}
+            onClick={this.clickNext}
             style={{ marginLeft: "24px" }}
           >
             Next

--- a/src/modules/auth/components/common/address-picker-content.jsx
+++ b/src/modules/auth/components/common/address-picker-content.jsx
@@ -29,14 +29,20 @@ export default class AddressPickerContent extends Component {
     this.clickNext = this.clickNext.bind(this);
   }
 
-  clickPrevious() {
+  clickPrevious(e) {
     if (!this.props.disablePrevious) {
+      e.stopPropagation();
+      e.preventDefault();
+
       this.props.clickPrevious();
     }
   }
 
-  clickNext() {
+  clickNext(e) {
     if (!this.props.disableNext) {
+      e.stopPropagation();
+      e.preventDefault();
+
       this.props.clickNext();
     }
   }

--- a/src/modules/auth/components/common/hardware-wallet.jsx
+++ b/src/modules/auth/components/common/hardware-wallet.jsx
@@ -309,11 +309,12 @@ export default class HardwareWallet extends Component {
       s.walletAddresses.length <=
       NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber;
 
-    const indexes = [
+    let indexes = [
       ...Array(NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber)
-    ]
-      .map((_, i) => i)
-      .slice(
+    ].map((_, i) => i);
+
+    if (s.cachedAddresses) {
+      indexes = indexes.slice(
         NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber -
           NUM_DERIVATION_PATHS_TO_DISPLAY,
         NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber >
@@ -321,6 +322,13 @@ export default class HardwareWallet extends Component {
           ? s.walletAddresses.length
           : NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber
       );
+    } else {
+      indexes = indexes.slice(
+        NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber -
+          NUM_DERIVATION_PATHS_TO_DISPLAY,
+        NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber
+      );
+    }
 
     let hideContent = false;
     if (isLoading && s.walletAddresses.every(element => !element)) {

--- a/src/modules/auth/components/common/hardware-wallet.jsx
+++ b/src/modules/auth/components/common/hardware-wallet.jsx
@@ -305,11 +305,9 @@ export default class HardwareWallet extends Component {
     } = this.props;
     const s = this.state;
 
-    const lessThanOnePageAddresses =
-      s.walletAddresses.length -
-        (NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber -
-          NUM_DERIVATION_PATHS_TO_DISPLAY) <
-      0;
+    const lessThanPageAddresses =
+      s.walletAddresses.length <=
+      NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber;
 
     const indexes = [
       ...Array(NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber)
@@ -365,7 +363,7 @@ export default class HardwareWallet extends Component {
                 clickPrevious={this.previous}
                 clickNext={this.next}
                 disablePrevious={s.addressPageNumber === 1}
-                disableNext={lessThanOnePageAddresses && s.cachedAddresses}
+                disableNext={lessThanPageAddresses && s.cachedAddresses}
               />
             )}
 

--- a/src/modules/auth/components/common/hardware-wallet.jsx
+++ b/src/modules/auth/components/common/hardware-wallet.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
+import { createBigNumber } from "utils/create-big-number";
 import DerivationPath, {
   DEFAULT_DERIVATION_PATH,
   DERIVATION_PATHS,
@@ -12,7 +12,7 @@ import DerivationPathEditor from "modules/auth/components/common/derivation-path
 import toggleHeight from "utils/toggle-height/toggle-height";
 import { ERROR_TYPES } from "modules/auth/constants/connect-nav";
 import { errorIcon } from "modules/common/components/icons";
-import { filter, orderBy } from "lodash";
+import { filter } from "lodash";
 import Styles from "modules/auth/components/common/hardware-wallet.styles";
 import StylesDropdown from "modules/auth/components/connect-dropdown/connect-dropdown.styles";
 import StylesError from "modules/auth/components/common/error-container.styles";
@@ -34,6 +34,12 @@ export default class HardwareWallet extends Component {
     onDerivationPathChange: PropTypes.func.isRequired,
     validation: PropTypes.func.isRequired
   };
+
+  static sortBalanceDesc(obj1, obj2) {
+    return createBigNumber(obj2.balance)
+      .minus(createBigNumber(obj1.balance))
+      .toFixed();
+  }
 
   constructor(props) {
     super(props);
@@ -217,10 +223,8 @@ export default class HardwareWallet extends Component {
             });
 
             const walletAddressesWithBalances = sortAndfilterBalances
-              ? orderBy(
-                  filter(walletAddresses, item => item.balance !== "0"),
-                  ["balance"],
-                  ["desc"]
+              ? filter(walletAddresses, item => item.balance !== "0").sort(
+                  HardwareWallet.sortBalanceDesc
                 )
               : walletAddresses;
 

--- a/src/modules/auth/components/common/hardware-wallet.jsx
+++ b/src/modules/auth/components/common/hardware-wallet.jsx
@@ -49,7 +49,8 @@ export default class HardwareWallet extends Component {
       baseDerivationPath: DEFAULT_DERIVATION_PATH,
       walletAddresses: new Array(NUM_DERIVATION_PATHS_TO_DISPLAY).fill(null),
       addressPageNumber: 1,
-      showWallet: false
+      showWallet: false,
+      cachedAddresses: false
     };
 
     this.updateDisplayInstructions = this.updateDisplayInstructions.bind(this);
@@ -142,7 +143,8 @@ export default class HardwareWallet extends Component {
 
     this.setState({
       walletAddresses,
-      addressPageNumber: pageNumber
+      addressPageNumber: pageNumber,
+      cachedAddresses: false
     });
 
     setIsLoading(false);
@@ -168,7 +170,8 @@ export default class HardwareWallet extends Component {
     if (walletAddresses.length > 0) {
       this.setState({
         walletAddresses,
-        addressPageNumber: 1
+        addressPageNumber: 1,
+        cachedAddresses: true
       });
       setIsLoading(false);
     } else {
@@ -272,12 +275,17 @@ export default class HardwareWallet extends Component {
   }
 
   next() {
-    const { addressPageNumber } = this.state;
-    this.getWalletAddresses(
-      this.state.baseDerivationPath,
-      addressPageNumber + 1,
-      false
-    );
+    const { cachedAddresses, addressPageNumber } = this.state;
+    if (!cachedAddresses) {
+      this.getWalletAddresses(
+        this.state.baseDerivationPath,
+        addressPageNumber + 1,
+        false
+      );
+    }
+    this.setState({
+      addressPageNumber: addressPageNumber + 1
+    });
   }
 
   previous() {
@@ -298,8 +306,10 @@ export default class HardwareWallet extends Component {
     const s = this.state;
 
     const lessThanOnePageAddresses =
-      s.walletAddresses.length <
-      NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber;
+      s.walletAddresses.length -
+        (NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber -
+          NUM_DERIVATION_PATHS_TO_DISPLAY) <
+      0;
 
     const indexes = [
       ...Array(NUM_DERIVATION_PATHS_TO_DISPLAY * s.addressPageNumber)
@@ -355,7 +365,7 @@ export default class HardwareWallet extends Component {
                 clickPrevious={this.previous}
                 clickNext={this.next}
                 disablePrevious={s.addressPageNumber === 1}
-                disableNext={lessThanOnePageAddresses}
+                disableNext={lessThanOnePageAddresses && s.cachedAddresses}
               />
             )}
 

--- a/src/modules/auth/components/common/hardware-wallet.jsx
+++ b/src/modules/auth/components/common/hardware-wallet.jsx
@@ -11,7 +11,7 @@ import DerivationPathEditor from "modules/auth/components/common/derivation-path
 import toggleHeight from "utils/toggle-height/toggle-height";
 import { ERROR_TYPES } from "modules/auth/constants/connect-nav";
 import { errorIcon } from "modules/common/components/icons";
-
+import { each } from "lodash";
 import Styles from "modules/auth/components/common/hardware-wallet.styles";
 import StylesDropdown from "modules/auth/components/connect-dropdown/connect-dropdown.styles";
 import StylesError from "modules/auth/components/common/error-container.styles";
@@ -140,6 +140,11 @@ export default class HardwareWallet extends Component {
     });
 
     if (result.success) {
+      const walletAddresses = [];
+      each(result.addresses, (item, index) => {
+        walletAddresses.push({ address: item, index });
+      });
+
       this.setState({
         baseDerivationPath: derivationPath,
         walletAddresses: result.addresses,

--- a/src/modules/auth/components/common/hardware-wallet.jsx
+++ b/src/modules/auth/components/common/hardware-wallet.jsx
@@ -180,10 +180,10 @@ export default class HardwareWallet extends Component {
     let walletAddresses = [];
     return new Promise((resolve, reject) => {
       onDerivationPathChange(paths, pageNumber) // only get 1 pages worth of addresses
-        .catch(() => {
+        .catch(e => {
           this.updateDisplayInstructions(true);
           setIsLoading(false);
-          reject();
+          reject(new Error(e));
         })
         .then(result => {
           if (result && result.success) {
@@ -191,13 +191,13 @@ export default class HardwareWallet extends Component {
           } else {
             this.updateDisplayInstructions(true);
             setIsLoading(false);
-            reject(); // no addresses found
+            reject(new Error("no addresses found")); // no addresses found
           }
           const promises = [];
           walletAddresses.forEach(addr => {
             const getPromise = new Promise((resolve, reject) => {
               getEtherBalance(addr.address, (err, balance, address) => {
-                if (err) return reject();
+                if (err) return reject(new Error(err));
                 resolve({ balance, address });
               });
             });

--- a/src/modules/auth/components/ledger-connect/ledger-connect.jsx
+++ b/src/modules/auth/components/ledger-connect/ledger-connect.jsx
@@ -41,24 +41,21 @@ export default class Ledger extends Component {
     // ledger can only take one request at a time, can't stack up promises
     /* eslint-disable */
     for (const index of indexes) {
+      const derivationPath = DerivationPath.buildString(
+        DerivationPath.increment(components, index)
+      );
       const result = await ledgerEthereum
-        .getAddress(
-          DerivationPath.buildString(
-            DerivationPath.increment(components, index)
-          ),
-          false,
-          true
-        )
+        .getAddress(derivationPath, false, true)
         .catch(err => {
           console.log("Error:", err);
           return { success: false };
         });
-      addresses.push(result && result.address);
+      addresses.push(result && { address: result.address, derivationPath });
     }
     /* eslint-enable */
 
     if (addresses && addresses.length > 0) {
-      if (!addresses.every(element => !element)) {
+      if (!addresses.every(element => !element.address)) {
         return { success: true, addresses };
       }
     }

--- a/src/modules/auth/components/ledger-connect/ledger-connect.jsx
+++ b/src/modules/auth/components/ledger-connect/ledger-connect.jsx
@@ -29,28 +29,29 @@ export default class Ledger extends Component {
     return true;
   }
 
-  static async onDerivationPathChange(derivationPath, pageNumber = 1) {
+  static async onDerivationPathChange(derivationPaths, pageNumber = 1) {
     const transport = await TransportU2F.create();
     const ledgerEthereum = new Eth(transport);
-
-    const components = DerivationPath.parse(derivationPath);
-    const numberOfAddresses = NUM_DERIVATION_PATHS_TO_DISPLAY * pageNumber;
-    const indexes = Array.from(Array(numberOfAddresses).keys());
     const addresses = [];
 
-    // ledger can only take one request at a time, can't stack up promises
     /* eslint-disable */
-    for (const index of indexes) {
-      const derivationPath = DerivationPath.buildString(
-        DerivationPath.increment(components, index)
-      );
-      const result = await ledgerEthereum
-        .getAddress(derivationPath, false, true)
-        .catch(err => {
-          console.log("Error:", err);
-          return { success: false };
-        });
-      addresses.push(result && { address: result.address, derivationPath });
+    for (const derivationPath of derivationPaths) {
+      const components = DerivationPath.parse(derivationPath);
+      const numberOfAddresses = NUM_DERIVATION_PATHS_TO_DISPLAY * pageNumber;
+      const indexes = Array.from(Array(numberOfAddresses).keys());
+      for (const index of indexes) {
+        const derivationPath = DerivationPath.buildString(
+          DerivationPath.increment(components, index)
+        );
+        // ledger can only take one request at a time, can't stack up promises
+        const result = await ledgerEthereum
+          .getAddress(derivationPath, false, true)
+          .catch(err => {
+            console.log("Error:", err);
+            return { success: false };
+          });
+        addresses.push(result && { address: result.address, derivationPath });
+      }
     }
     /* eslint-enable */
 

--- a/src/modules/auth/components/trezor-connect/trezor-connect.jsx
+++ b/src/modules/auth/components/trezor-connect/trezor-connect.jsx
@@ -20,22 +20,27 @@ export default class TrezorConnect extends Component {
     isLoading: PropTypes.bool.isRequired
   };
 
-  static async onDerivationPathChange(derivationPath, pageNumber = 1) {
-    const components = DerivationPath.parse(derivationPath);
-    const numberOfAddresses = NUM_DERIVATION_PATHS_TO_DISPLAY * pageNumber;
-    const indexes = Array.from(Array(numberOfAddresses).keys());
+  static async onDerivationPathChange(derivationPaths, pageNumber = 1) {
+    const paths = [];
+
+    derivationPaths.forEach(derivationPath => {
+      const components = DerivationPath.parse(derivationPath);
+      const numberOfAddresses = NUM_DERIVATION_PATHS_TO_DISPLAY * pageNumber;
+      const indexes = Array.from(Array(numberOfAddresses).keys());
+      indexes.forEach(index => {
+        const derivationPath = DerivationPath.buildString(
+          DerivationPath.increment(components, index)
+        );
+        paths.push(derivationPath);
+      });
+    });
+
     const addresses = [];
 
-    const bundle = indexes.map(index => {
-      const showOnTrezor = false;
-      const path = DerivationPath.buildString(
-        DerivationPath.increment(components, index)
-      );
-      return {
-        path,
-        showOnTrezor
-      };
-    });
+    const bundle = paths.map(path => ({
+      path,
+      showOnTrezor: false
+    }));
 
     const response = await TrezorConnectImport.ethereumGetAddress({
       bundle
@@ -47,7 +52,11 @@ export default class TrezorConnect extends Component {
     if (response.success) {
       // parse up the bundle results
       response.payload.every(item =>
-        addresses.push({ address: item.address, derivationPath: item.path })
+        addresses.push({
+          address: item.address,
+          derivationPath: item.path,
+          serializedPath: item.serializedPath
+        })
       );
       if (addresses && addresses.length > 0) {
         if (!addresses.every(element => !element.address)) {
@@ -92,6 +101,8 @@ export default class TrezorConnect extends Component {
           derivationPath
         );
       }
+    } else {
+      console.error("Could not connect to Trezor");
     }
   }
 

--- a/src/modules/auth/components/trezor-connect/trezor-connect.jsx
+++ b/src/modules/auth/components/trezor-connect/trezor-connect.jsx
@@ -46,9 +46,11 @@ export default class TrezorConnect extends Component {
 
     if (response.success) {
       // parse up the bundle results
-      response.payload.every(item => addresses.push(item.address));
+      response.payload.every(item =>
+        addresses.push({ address: item.address, derivationPath: item.path })
+      );
       if (addresses && addresses.length > 0) {
-        if (!addresses.every(element => !element)) {
+        if (!addresses.every(element => !element.address)) {
           return { success: true, addresses };
         }
       }

--- a/src/modules/auth/helpers/derivation-path.js
+++ b/src/modules/auth/helpers/derivation-path.js
@@ -1,10 +1,6 @@
 export const DEFAULT_DERIVATION_PATH = "m/44'/60'/0'/0/0";
 export const NUM_DERIVATION_PATHS_TO_DISPLAY = 5;
-export const DERIVATION_PATHS = [
-  "m/44'/60'/0'/0/0",
-  "m/44'/60'/0'/0",
-  "m/44'/60'/0'"
-];
+export const DERIVATION_PATHS = ["m/44'/60'/0'/0/0", "m/44'/60'/0'/0"];
 export default class DerivationPath {
   static validate(derivationPath) {
     return /^m\/(44)'\/(60)'\/(\d+)'(?:\/|\/(\d+))?(?:\/|\/(\d+))?$/.test(

--- a/src/modules/auth/helpers/derivation-path.js
+++ b/src/modules/auth/helpers/derivation-path.js
@@ -1,6 +1,10 @@
 export const DEFAULT_DERIVATION_PATH = "m/44'/60'/0'/0/0";
 export const NUM_DERIVATION_PATHS_TO_DISPLAY = 5;
-
+export const DERIVATION_PATHS = [
+  "m/44'/60'/0'/0/0",
+  "m/44'/60'/0'/0",
+  "m/44'/60'/0'"
+];
 export default class DerivationPath {
   static validate(derivationPath) {
     return /^m\/(44)'\/(60)'\/(\d+)'(?:\/|\/(\d+))?(?:\/|\/(\d+))?$/.test(

--- a/src/modules/market/components/common/outcome-trading-indicator/outcome-trading-indicator.jsx
+++ b/src/modules/market/components/common/outcome-trading-indicator/outcome-trading-indicator.jsx
@@ -43,7 +43,7 @@ export default function OutcomeTradingIndicator({
         case "positions|up":
           return { position: "absolute", bottom: "1.5rem" };
         case "positions|down":
-          return { position: "absolute", top: "0.945rem" };
+          return { position: "absolute", top: "1.3rem" };
         case "modileTradingForm|down":
           return { top: "1rem" };
         case "modileTradingForm|up":


### PR DESCRIPTION
Added scan feature to display addresses with balance from 2 derivation paths.
don't re-pull address information when user clicks <previous>
fixed login closing when Trezor user clicks next or previous.

closes bthaile/augur#288