### PR TITLE
because of race condition of displaying transactions when user is log…

### DIFF
--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -276,7 +276,7 @@ export function addCompleteSetsSoldLogs(completeSetsSoldLogs) {
         {
           message: "Complete Sets Sold",
           description: `${transaction.meta.amount} sold on Market: ${
-            market.description
+            (market || {}).description
           }`,
           transactions: [transaction]
         }


### PR DESCRIPTION
…ged in before market data is pulled, add a conditional when getting description


fixes bthaile/augur#504

This issue also occurs on local chain.