### PR TITLE
Johndanz/ch18150/transaction pg displaying transactions for

### DIFF
--- a/src/modules/transactions/actions/add-transactions.js
+++ b/src/modules/transactions/actions/add-transactions.js
@@ -289,7 +289,7 @@ export function addCompleteSetsSoldLogs(completeSetsSoldLogs) {
 
 export function addOpenOrderTransactions(openOrders) {
   return (dispatch, getState) => {
-    const { marketsData } = getState();
+    const { marketsData, transactionsData } = getState();
     // flatten open orders
     const transactions = {};
     eachOf(openOrders, (value, marketId) => {
@@ -357,11 +357,17 @@ export function addOpenOrderTransactions(openOrders) {
         });
       });
       // TODO: last order creation time will be in header, earliest activite
+      const currentTransactionsKeys = Object.keys(transactionsData);
+      const leadOrder = marketTradeTransactions.find(marketTransaction =>
+        currentTransactionsKeys.includes(marketTransaction.orderId)
+      );
       marketHeader.timestamp = creationTime;
       marketHeader.message = formatTransactionMessage(sumBuy, sumSell, "Order");
       marketHeader.type = OPEN_ORDER;
       marketHeader.transactions = marketTradeTransactions;
-      marketHeader.hash = `${marketTradeTransactions[0].orderId}`;
+      marketHeader.hash = leadOrder
+        ? leadOrder.orderId
+        : `${marketTradeTransactions[0].orderId}`;
       transactions[marketHeader.hash] = marketHeader;
     });
     dispatch(updateTransactionsData(transactions));

--- a/src/modules/transactions/actions/register-transaction-relay.js
+++ b/src/modules/transactions/actions/register-transaction-relay.js
@@ -16,8 +16,9 @@ export const handleRelayTransaction = tx => (dispatch, getState) => {
       // const gasPrice = augur.rpc.gasPrice || augur.constants.DEFAULT_GASPRICE
       // const gasFees = tx.response.gasFees || augur.trading.simulation.getTxGasEth({ ...tx.data }, gasPrice).toFixed()
       const gasFees = tx.response.gasFees || 0;
+      const isBlacklisted = blacklist.includes(type);
       if (hash) {
-        if (transactionsData[hash] && !blacklist.includes(type)) {
+        if (transactionsData[hash] && !isBlacklisted) {
           dispatch(constructRelayTransaction(tx));
           dispatch(
             updateTransactionsData({
@@ -33,7 +34,7 @@ export const handleRelayTransaction = tx => (dispatch, getState) => {
           transactionsData[hash].status !== SUCCESS
         ) {
           const relayTransaction = dispatch(constructRelayTransaction(tx));
-          if (relayTransaction && !blacklist.includes(type)) {
+          if (relayTransaction && !isBlacklisted) {
             dispatch(updateTransactionsData(relayTransaction));
           }
         }

--- a/src/modules/transactions/actions/register-transaction-relay.js
+++ b/src/modules/transactions/actions/register-transaction-relay.js
@@ -5,9 +5,11 @@ import { formatEther } from "utils/format-number";
 import { updateTransactionsData } from "modules/transactions/actions/update-transactions-data";
 import { constructRelayTransaction } from "modules/transactions/actions/construct-relay-transaction";
 
+const blacklist = ["publicCreateOrder"];
+
 export const handleRelayTransaction = tx => (dispatch, getState) => {
   if (tx && tx.response && tx.data) {
-    const { hash } = tx;
+    const { hash, type } = tx;
     if (!hash) return console.error("uncaught relayed transaction", tx);
     const { loginAccount, transactionsData } = getState();
     if (tx.data.from === loginAccount.address) {
@@ -15,7 +17,7 @@ export const handleRelayTransaction = tx => (dispatch, getState) => {
       // const gasFees = tx.response.gasFees || augur.trading.simulation.getTxGasEth({ ...tx.data }, gasPrice).toFixed()
       const gasFees = tx.response.gasFees || 0;
       if (hash) {
-        if (transactionsData[hash]) {
+        if (transactionsData[hash] && !blacklist.includes(type)) {
           dispatch(constructRelayTransaction(tx));
           dispatch(
             updateTransactionsData({
@@ -31,7 +33,7 @@ export const handleRelayTransaction = tx => (dispatch, getState) => {
           transactionsData[hash].status !== SUCCESS
         ) {
           const relayTransaction = dispatch(constructRelayTransaction(tx));
-          if (relayTransaction) {
+          if (relayTransaction && !blacklist.includes(type)) {
             dispatch(updateTransactionsData(relayTransaction));
           }
         }


### PR DESCRIPTION
to test, make a market with added liquidity, stay on the transactions page after signing the market creation transaction, and sign all the liquidity orders in rapid succession. Two things to look for:

Orders only appear on the transaction page when they've been placed.

Orders are grouped properly on only one open order transaction group for that market. (aka don't have multiple groups all referencing the same orders)

fixes johnDanz/augur/333