### PR TITLE
Add to error message to tell user to make sure contract data is enabled

### DIFF
--- a/src/modules/auth/helpers/ledger-signer.js
+++ b/src/modules/auth/helpers/ledger-signer.js
@@ -37,7 +37,7 @@ const ledgerSigner = async (rawTxArgs, ledgerLib, derivationPath, dispatch) => {
       dispatch(
         updateModal({
           type: MODAL_LEDGER,
-          error: `Failed to Sign with "${err}"`
+          error: `Failed to Sign with "${err}" On Leger device, Make sure Contract data is Enabled`
         })
       );
     });


### PR DESCRIPTION

Add to "On Leger device, Make sure Contract data is Enabled" to generic error when ledger signing fails.

