### PR TITLE
disable claim and finalize buttons

### DIFF
--- a/src/modules/market/components/core-properties/core-properties.jsx
+++ b/src/modules/market/components/core-properties/core-properties.jsx
@@ -90,6 +90,14 @@ export default class CoreProperties extends Component {
     isMobileSmall: false
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      disableFinalize: false
+    };
+  }
+
   determinePhase() {
     const { reportingState } = this.props.market;
     switch (reportingState) {
@@ -294,7 +302,15 @@ export default class CoreProperties extends Component {
                   </ReactTooltip>
                   <button
                     className={Styles[`CoreProperties__property-button`]}
-                    onClick={() => finalizeMarket(id)}
+                    onClick={() => {
+                      this.setState({ disableFinalize: true });
+                      finalizeMarket(id, err => {
+                        if (err) {
+                          this.setState({ disableFinalize: false });
+                        }
+                      });
+                    }}
+                    disabled={this.state.disableFinalize}
                   >
                     FINALIZE
                   </button>

--- a/src/modules/market/components/market-outstanding-returns/market-outstanding-returns.jsx
+++ b/src/modules/market/components/market-outstanding-returns/market-outstanding-returns.jsx
@@ -1,41 +1,55 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 import Styles from "modules/market/components/market-outstanding-returns/market-outstanding-returns.styles";
 
-const OutstandingReturns = ({
-  id,
-  unclaimedCreatorFees,
-  collectMarketCreatorFees
-}) => (
-  <div className={Styles.MarketOutstandingReturns}>
-    <div className={Styles.MarketOutstandingReturns__text}>
-      Outstanding Returns
-      <span
-        className={Styles.MarketOutstandingReturns__value}
-        data-testid={"unclaimedCreatorFees-" + id}
-      >
-        {unclaimedCreatorFees.full}
-      </span>
-    </div>
-    <div className={Styles.MarketOutstandingReturns__actions}>
-      <button
-        className={Styles.MarketOutstandingReturns__collect}
-        data-testid={"collectMarketCreatorFees-" + id}
-        onClick={() => {
-          collectMarketCreatorFees(false, id);
-        }}
-      >
-        Claim
-      </button>
-    </div>
-  </div>
-);
+export default class MarketPreview extends Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    unclaimedCreatorFees: PropTypes.object.isRequired,
+    collectMarketCreatorFees: PropTypes.func.isRequired
+  };
 
-OutstandingReturns.propTypes = {
-  id: PropTypes.string.isRequired,
-  unclaimedCreatorFees: PropTypes.object.isRequired,
-  collectMarketCreatorFees: PropTypes.func.isRequired
-};
+  constructor(props) {
+    super(props);
 
-export default OutstandingReturns;
+    this.state = {
+      disableClaim: false
+    };
+  }
+
+  render() {
+    const { id, unclaimedCreatorFees, collectMarketCreatorFees } = this.props;
+
+    return (
+      <div className={Styles.MarketOutstandingReturns}>
+        <div className={Styles.MarketOutstandingReturns__text}>
+          Outstanding Returns
+          <span
+            className={Styles.MarketOutstandingReturns__value}
+            data-testid={"unclaimedCreatorFees-" + id}
+          >
+            {unclaimedCreatorFees.full}
+          </span>
+        </div>
+        <div className={Styles.MarketOutstandingReturns__actions}>
+          <button
+            className={Styles.MarketOutstandingReturns__collect}
+            data-testid={"collectMarketCreatorFees-" + id}
+            disabled={this.state.disableClaim}
+            onClick={() => {
+              this.setState({ disableClaim: true });
+              collectMarketCreatorFees(false, id, err => {
+                if (err) {
+                  this.setState({ disableClaim: false });
+                }
+              });
+            }}
+          >
+            Claim
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/modules/market/components/market-properties/market-properties.jsx
+++ b/src/modules/market/components/market-properties/market-properties.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
@@ -34,249 +34,270 @@ const ShowResolutionStates = [
   AWAITING_NEXT_WINDOW
 ];
 
-const MarketProperties = ({
-  marketType,
-  openInterest,
-  volume,
-  isForking,
-  loginAccount,
-  reportingState,
-  settlementFeePercent,
-  currentTimestamp,
-  endTime,
-  resolutionSource,
-  id,
-  isLogged,
-  isMobile,
-  toggleFavorite,
-  isFavorite,
-  finalizeMarket,
-  isForkingMarketFinalized,
-  forkingMarket,
-  updateModal,
-  description,
-  showAdditionalDetailsToggle,
-  showingDetails,
-  finalizationTime,
-  toggleDetails,
-  ...p
-}) => {
-  const isScalar = marketType === SCALAR;
-  let consensus = getValue(
-    p,
-    isScalar ? "consensus.winningOutcome" : "consensus.outcomeName"
-  );
-  const linkType =
-    isForking && p.linkType === TYPE_DISPUTE ? TYPE_VIEW : p.linkType;
-  const disableDispute =
-    loginAccount.rep === "0" && p.linkType === TYPE_DISPUTE;
-  if (getValue(p, "consensus.isInvalid")) {
-    consensus = "Invalid";
-  }
-  const showResolution = ShowResolutionStates.indexOf(reportingState) !== -1;
+export default class MarketProperties extends Component {
+  static propTypes = {
+    currentTimestamp: PropTypes.number.isRequired,
+    updateModal: PropTypes.func.isRequired,
+    linkType: PropTypes.string,
+    finalizationTime: PropTypes.number,
+    showAdditionalDetailsToggle: PropTypes.bool,
+    showingDetails: PropTypes.bool,
+    toggleDetails: PropTypes.func,
+    isForking: PropTypes.bool,
+    isForkingMarketFinalized: PropTypes.bool,
+    forkingMarket: PropTypes.string,
+    resolutionSource: PropTypes.string,
+    marketType: PropTypes.string,
+    openInterest: PropTypes.object,
+    volume: PropTypes.object,
+    loginAccount: PropTypes.object,
+    reportingState: PropTypes.string,
+    settlementFeePercent: PropTypes.object,
+    endTime: PropTypes.object,
+    id: PropTypes.string,
+    isLogged: PropTypes.bool,
+    isMobile: PropTypes.bool,
+    toggleFavorite: PropTypes.func,
+    isFavorite: PropTypes.bool,
+    finalizeMarket: PropTypes.func,
+    description: PropTypes.string
+  };
 
-  return (
-    <article>
-      <section className={Styles.MarketProperties}>
-        <ul className={Styles.MarketProperties__meta}>
-          <li>
-            <span>Volume</span>
-            <ValueDenomination
-              valueClassname="volume"
-              formatted={volume.full}
-            />
-          </li>
-          <li>
-            <span>Open Interest</span>
-            <ValueDenomination
-              valueClassname="volume"
-              formatted={openInterest.full}
-            />
-          </li>
-          <li>
-            <span>Est. Fee</span>
-            <ValueDenomination valueClassname="fee" {...settlementFeePercent} />
-          </li>
-          <li>
-            <span>
-              {endTime && dateHasPassed(currentTimestamp, endTime.timestamp)
-                ? "Expired"
-                : "Expires"}
-            </span>
-            <span className="value_expires">
-              {isMobile
-                ? endTime.formattedLocalShort
-                : endTime.formattedLocalShortTime}
-            </span>
-          </li>
-          {showResolution && (
-            <li className={Styles.MarketProperties__resolutionSource}>
-              <span>Resolution Source</span>
-              <span
-                className={classNames(
-                  Styles.MarketProperties__resolutionSource,
-                  {
-                    [Styles.MarketProperties__resolutionSourceDoubleButtons]:
-                      isForking &&
-                      isForkingMarketFinalized &&
-                      forkingMarket !== id &&
-                      !finalizationTime
-                  }
-                )}
-              >
-                {resolutionSource || "General knowledge"}
+  static defaultProps = {
+    linkType: null,
+    finalizationTime: null,
+    showAdditionalDetailsToggle: false,
+    showingDetails: false,
+    isForking: false,
+    isForkingMarketFinalized: false,
+    forkingMarket: null,
+    toggleDetails: () => {},
+    resolutionSource: "General Knowledge",
+    marketType: null,
+    openInterest: null,
+    volume: null,
+    loginAccount: null,
+    reportingState: null,
+    settlementFeePercent: null,
+    endTime: null,
+    id: null,
+    isLogged: false,
+    isMobile: false,
+    toggleFavorite: () => {},
+    isFavorite: false,
+    finalizeMarket: () => {},
+    description: null
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      disableFinalize: false
+    };
+  }
+
+  render() {
+    const p = this.props;
+    const {
+      marketType,
+      openInterest,
+      volume,
+      isForking,
+      loginAccount,
+      reportingState,
+      settlementFeePercent,
+      currentTimestamp,
+      endTime,
+      resolutionSource,
+      id,
+      isLogged,
+      isMobile,
+      toggleFavorite,
+      isFavorite,
+      finalizeMarket,
+      isForkingMarketFinalized,
+      forkingMarket,
+      updateModal,
+      description,
+      showAdditionalDetailsToggle,
+      showingDetails,
+      finalizationTime,
+      toggleDetails
+    } = this.props;
+
+    const isScalar = marketType === SCALAR;
+    let consensus = getValue(
+      p,
+      isScalar ? "consensus.winningOutcome" : "consensus.outcomeName"
+    );
+    const linkType =
+      isForking && p.linkType === TYPE_DISPUTE ? TYPE_VIEW : p.linkType;
+    const disableDispute =
+      loginAccount.rep === "0" && p.linkType === TYPE_DISPUTE;
+    if (getValue(p, "consensus.isInvalid")) {
+      consensus = "Invalid";
+    }
+    const showResolution = ShowResolutionStates.indexOf(reportingState) !== -1;
+
+    return (
+      <article>
+        <section className={Styles.MarketProperties}>
+          <ul className={Styles.MarketProperties__meta}>
+            <li>
+              <span>Volume</span>
+              <ValueDenomination
+                valueClassname="volume"
+                formatted={volume.full}
+              />
+            </li>
+            <li>
+              <span>Open Interest</span>
+              <ValueDenomination
+                valueClassname="volume"
+                formatted={openInterest.full}
+              />
+            </li>
+            <li>
+              <span>Est. Fee</span>
+              <ValueDenomination
+                valueClassname="fee"
+                {...settlementFeePercent}
+              />
+            </li>
+            <li>
+              <span>
+                {endTime && dateHasPassed(currentTimestamp, endTime.timestamp)
+                  ? "Expired"
+                  : "Expires"}
+              </span>
+              <span className="value_expires">
+                {isMobile
+                  ? endTime.formattedLocalShort
+                  : endTime.formattedLocalShortTime}
               </span>
             </li>
-          )}
-          {consensus && (
-            <li>
-              <span>Winning Outcome</span>
-              {consensus}
-            </li>
-          )}
-        </ul>
-        <div className={Styles.MarketProperties__actions}>
-          {isLogged &&
-            toggleFavorite && (
-              <button
-                className={classNames(Styles.MarketProperties__favorite, {
-                  [Styles.favorite]: isFavorite
-                })}
-                onClick={() => toggleFavorite(id)}
-              >
-                {isFavorite ? (
-                  <i className="fa fa-star" />
-                ) : (
-                  <i className="fa fa-star-o" />
-                )}
-              </button>
+            {showResolution && (
+              <li className={Styles.MarketProperties__resolutionSource}>
+                <span>Resolution Source</span>
+                <span
+                  className={classNames(
+                    Styles.MarketProperties__resolutionSource,
+                    {
+                      [Styles.MarketProperties__resolutionSourceDoubleButtons]:
+                        isForking &&
+                        isForkingMarketFinalized &&
+                        forkingMarket !== id &&
+                        !finalizationTime
+                    }
+                  )}
+                >
+                  {resolutionSource || "General knowledge"}
+                </span>
+              </li>
             )}
-          {(!linkType ||
-            (linkType &&
-              linkType !== TYPE_FINALIZE_MARKET &&
-              linkType !== TYPE_CLAIM_PROCEEDS)) && (
-            <MarketLink
-              className={classNames(Styles.MarketProperties__trade, {
-                [Styles.disabled]: disableDispute
-              })}
-              id={id}
-              linkType={linkType}
-            >
-              {linkType || "view"}
-            </MarketLink>
-          )}
-          {linkType &&
-            linkType === TYPE_FINALIZE_MARKET &&
-            !finalizationTime && (
-              <button
-                className={Styles.MarketProperties__trade}
-                onClick={e => finalizeMarket(id)}
-              >
-                Finalize
-              </button>
+            {consensus && (
+              <li>
+                <span>Winning Outcome</span>
+                {consensus}
+              </li>
             )}
-          {linkType &&
-            linkType !== TYPE_VIEW &&
-            linkType !== TYPE_TRADE &&
-            finalizationTime && (
+          </ul>
+          <div className={Styles.MarketProperties__actions}>
+            {isLogged &&
+              toggleFavorite && (
+                <button
+                  className={classNames(Styles.MarketProperties__favorite, {
+                    [Styles.favorite]: isFavorite
+                  })}
+                  onClick={() => toggleFavorite(id)}
+                >
+                  {isFavorite ? (
+                    <i className="fa fa-star" />
+                  ) : (
+                    <i className="fa fa-star-o" />
+                  )}
+                </button>
+              )}
+            {(!linkType ||
+              (linkType &&
+                linkType !== TYPE_FINALIZE_MARKET &&
+                linkType !== TYPE_CLAIM_PROCEEDS)) && (
               <MarketLink
                 className={classNames(Styles.MarketProperties__trade, {
                   [Styles.disabled]: disableDispute
                 })}
                 id={id}
-                linkType={TYPE_VIEW}
+                linkType={linkType}
               >
-                {TYPE_VIEW}
+                {linkType || "view"}
               </MarketLink>
             )}
-          {isForking &&
-            isForkingMarketFinalized &&
-            forkingMarket !== id &&
-            !finalizationTime && (
-              <button
-                className={Styles.MarketProperties__migrate}
-                onClick={() =>
-                  updateModal({
-                    type: MODAL_MIGRATE_MARKET,
-                    marketId: id,
-                    marketDescription: description
-                  })
-                }
-              >
-                Migrate
-              </button>
-            )}
-        </div>
-      </section>
-      {showAdditionalDetailsToggle && (
-        <button
-          className={Styles[`MarketProperties__additional-details`]}
-          onClick={() => toggleDetails()}
-        >
-          Additional Details
-          <span
-            className={Styles["MarketProperties__additional-details-chevron"]}
+            {linkType &&
+              linkType === TYPE_FINALIZE_MARKET &&
+              !finalizationTime && (
+                <button
+                  className={Styles.MarketProperties__trade}
+                  onClick={e => {
+                    this.setState({ disableFinalize: true });
+                    finalizeMarket(id, (err, res) => {
+                      if (err) {
+                        this.setState({ disableFinalize: false });
+                      }
+                    });
+                  }}
+                  disabled={this.state.disableFinalize}
+                >
+                  Finalize
+                </button>
+              )}
+            {linkType &&
+              linkType !== TYPE_VIEW &&
+              linkType !== TYPE_TRADE &&
+              finalizationTime && (
+                <MarketLink
+                  className={classNames(Styles.MarketProperties__trade, {
+                    [Styles.disabled]: disableDispute
+                  })}
+                  id={id}
+                  linkType={TYPE_VIEW}
+                >
+                  {TYPE_VIEW}
+                </MarketLink>
+              )}
+            {isForking &&
+              isForkingMarketFinalized &&
+              forkingMarket !== id &&
+              !finalizationTime && (
+                <button
+                  className={Styles.MarketProperties__migrate}
+                  onClick={() =>
+                    updateModal({
+                      type: MODAL_MIGRATE_MARKET,
+                      marketId: id,
+                      marketDescription: description
+                    })
+                  }
+                >
+                  Migrate
+                </button>
+              )}
+          </div>
+        </section>
+        {showAdditionalDetailsToggle && (
+          <button
+            className={Styles[`MarketProperties__additional-details`]}
+            onClick={() => toggleDetails()}
           >
-            <ChevronFlip pointDown={showingDetails} />
-          </span>
-        </button>
-      )}
-    </article>
-  );
-};
-
-MarketProperties.propTypes = {
-  currentTimestamp: PropTypes.number.isRequired,
-  updateModal: PropTypes.func.isRequired,
-  linkType: PropTypes.string,
-  finalizationTime: PropTypes.number,
-  showAdditionalDetailsToggle: PropTypes.bool,
-  showingDetails: PropTypes.bool,
-  toggleDetails: PropTypes.func,
-  isForking: PropTypes.bool,
-  isForkingMarketFinalized: PropTypes.bool,
-  forkingMarket: PropTypes.string,
-  resolutionSource: PropTypes.string,
-  marketType: PropTypes.string,
-  openInterest: PropTypes.object,
-  volume: PropTypes.object,
-  loginAccount: PropTypes.object,
-  reportingState: PropTypes.string,
-  settlementFeePercent: PropTypes.object,
-  endTime: PropTypes.object,
-  id: PropTypes.string,
-  isLogged: PropTypes.bool,
-  isMobile: PropTypes.bool,
-  toggleFavorite: PropTypes.func,
-  isFavorite: PropTypes.bool,
-  finalizeMarket: PropTypes.func,
-  description: PropTypes.string
-};
-
-MarketProperties.defaultProps = {
-  linkType: null,
-  finalizationTime: null,
-  showAdditionalDetailsToggle: false,
-  showingDetails: false,
-  isForking: false,
-  isForkingMarketFinalized: false,
-  forkingMarket: null,
-  toggleDetails: () => {},
-  resolutionSource: "General Knowledge",
-  marketType: null,
-  openInterest: null,
-  volume: null,
-  loginAccount: null,
-  reportingState: null,
-  settlementFeePercent: null,
-  endTime: null,
-  id: null,
-  isLogged: false,
-  isMobile: false,
-  toggleFavorite: () => {},
-  isFavorite: false,
-  finalizeMarket: () => {},
-  description: null
-};
-
-export default MarketProperties;
+            Additional Details
+            <span
+              className={Styles["MarketProperties__additional-details-chevron"]}
+            >
+              <ChevronFlip pointDown={showingDetails} />
+            </span>
+          </button>
+        )}
+      </article>
+    );
+  }
+}

--- a/src/modules/market/containers/market-header.js
+++ b/src/modules/market/containers/market-header.js
@@ -34,7 +34,7 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  finalizeMarket: marketId => dispatch(sendFinalizeMarket(marketId))
+  finalizeMarket: (marketId, cb) => dispatch(sendFinalizeMarket(marketId, cb))
 });
 
 const MarketHeaderContainer = withRouter(

--- a/src/modules/market/containers/market-properties.js
+++ b/src/modules/market/containers/market-properties.js
@@ -24,7 +24,7 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = dispatch => ({
   updateModal: modal => dispatch(updateModal(modal)),
-  finalizeMarket: marketId => dispatch(sendFinalizeMarket(marketId))
+  finalizeMarket: (marketId, cb) => dispatch(sendFinalizeMarket(marketId, cb))
 });
 
 const MarketPropertiesContainer = withRouter(

--- a/src/modules/markets/actions/finalize-market.js
+++ b/src/modules/markets/actions/finalize-market.js
@@ -13,7 +13,9 @@ export const sendFinalizeMarket = (marketId, callback = logError) => (
     tx: { to: marketId },
     meta: loginAccount.meta,
     onSent: noop,
-    onSuccess: noop,
+    onSuccess: () => {
+      callback(null);
+    },
     onFailed: err => callback(err)
   });
 };

--- a/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card-footer.jsx
+++ b/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card-footer.jsx
@@ -22,7 +22,8 @@ const MarketPortfolioCardFooter = ({
   marketId,
   buttonAction,
   localButtonText,
-  claimClicked
+  claimClicked,
+  disabled
 }) => {
   const WrappedGraph = TimeRemainingIndicatorWrapper(SingleSlicePieGraph);
   let canClaim = false;
@@ -112,7 +113,8 @@ const MarketPortfolioCardFooter = ({
                 (linkType === TYPE_CLAIM_PROCEEDS &&
                   !canClaim &&
                   !userHasClaimableForkFees) ||
-                claimClicked
+                claimClicked ||
+                disabled
               }
             >
               {localButtonText}
@@ -134,14 +136,16 @@ MarketPortfolioCardFooter.propTypes = {
   unclaimedForkEth: PropTypes.object,
   marketId: PropTypes.string.isRequired,
   unclaimedForkRepStaked: PropTypes.object,
-  claimClicked: PropTypes.bool
+  claimClicked: PropTypes.bool,
+  disabled: PropTypes.bool
 };
 
 MarketPortfolioCardFooter.defaultProps = {
   unclaimedForkEth: null,
   unclaimedForkRepStaked: null,
   finalizationTime: null,
-  claimClicked: false
+  claimClicked: false,
+  disabled: false
 };
 
 export default MarketPortfolioCardFooter;

--- a/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card.jsx
+++ b/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card.jsx
@@ -46,7 +46,8 @@ export default class MarketPortfolioCard extends Component {
         myPositions: positionsDefault,
         openOrders: orphanedOrders.length > 0 // open if orphaned orders are present
       },
-      claimClicked: false
+      claimClicked: false,
+      disableFinalize: false
     };
   }
 
@@ -67,14 +68,17 @@ export default class MarketPortfolioCard extends Component {
 
   finalizeMarket = () => {
     const { finalizeMarket, market } = this.props;
-    finalizeMarket(market.id);
+    this.setState({ disableFinalize: true });
+    finalizeMarket(market.id, err => {
+      if (err) this.setState({ disableFinalize: false });
+    });
   };
 
   claimProceeds = () => {
     const { claimTradingProceeds, market } = this.props;
     this.setState({ claimClicked: true });
-    claimTradingProceeds(market.id, () => {
-      this.setState({ claimClicked: false });
+    claimTradingProceeds(market.id, err => {
+      if (err) this.setState({ claimClicked: false });
     });
   };
 
@@ -87,20 +91,23 @@ export default class MarketPortfolioCard extends Component {
       orphanedOrders,
       cancelOrphanedOrder
     } = this.props;
-    const { tableOpen, claimClicked } = this.state;
+    const { tableOpen, claimClicked, disableFinalize } = this.state;
     const myPositionsSummary = getValue(market, "myPositionsSummary");
     const myPositionOutcomes = getValue(market, "outcomes");
 
     let localButtonText;
     let buttonAction;
+    let disabled = false;
     switch (linkType) {
       case TYPE_CLAIM_PROCEEDS:
         localButtonText = "Claim Proceeds";
         buttonAction = this.claimProceeds;
+        disabled = claimClicked;
         break;
       case TYPE_FINALIZE_MARKET:
         localButtonText = "Finalize Market";
         buttonAction = this.finalizeMarket;
+        disabled = disableFinalize;
         break;
       default:
         localButtonText = "View";
@@ -402,6 +409,7 @@ export default class MarketPortfolioCard extends Component {
               currentTimestamp={currentTimestamp}
               marketId={market.id}
               claimClicked={linkType === TYPE_CLAIM_PROCEEDS && claimClicked}
+              disabled={disabled}
             />
           )}
       </article>

--- a/src/modules/portfolio/containers/market-portfolio-card.js
+++ b/src/modules/portfolio/containers/market-portfolio-card.js
@@ -44,7 +44,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   getWinningBalances: marketIds => dispatch(getWinningBalance(marketIds)),
-  finalizeMarket: marketId => dispatch(sendFinalizeMarket(marketId)),
+  finalizeMarket: (marketId, cb) => dispatch(sendFinalizeMarket(marketId, cb)),
   cancelOrphanedOrder: (order, cb) => dispatch(cancelOrphanedOrder(order, cb)),
   claimTradingProceeds: (marketId, cb) =>
     dispatch(updateModal({ type: MODAL_CLAIM_TRADING_PROCEEDS, marketId, cb }))


### PR DESCRIPTION
fixes https://github.com/AugurProject/augur/issues/629

- disabled "claim" button for market creators in /my-markets tab
- also did the same for the "finalize" button on market trading page, market portfolio card, and market cards (or core properties, where it shows up in /my-markets) 

to test:
1. create a market
2. make a position on that market
3. push market to finalization time
4. from here, can test claiming market creator fees, finalizing, and claim proceeds buttons