### PR TITLE
Add invalid market blurb to report/dispute forms

### DIFF
--- a/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
+++ b/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.jsx
@@ -454,6 +454,14 @@ export default class ReportingDisputeForm extends Component {
         )}
       >
         <li>
+          <div className={Styles.ReportingDisputeForm__outcome_selection_msg}>
+            Please choose an outcome below based on the resolution source at the
+            time the market ended. The market should be considered invalid if it
+            is opinion-based, unclear, has more than one valid outcome, or the
+            outcome wasn&#39;t known when the market ended.
+          </div>
+        </li>
+        <li>
           <label>
             <span>Tentative Winning Outcome</span>
           </label>

--- a/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.styles.less
+++ b/src/modules/reporting/components/reporting-dispute-form/reporting-dispute-form.styles.less
@@ -134,6 +134,14 @@ ul.ReportingDisputeForm__fields {
   white-space: nowrap;
 }
 
+.ReportingDisputeForm__outcome_selection_msg {
+  color: @color-white;
+  font-size: 1rem;
+  line-height: 1rem;
+  position: relative;
+  top: 0.25rem;
+}
+
 .ReportingReport__malformed_msg {
   color: @color-negative;
   font-size: 1rem;

--- a/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
+++ b/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
@@ -201,6 +201,14 @@ export default class ReportingReportForm extends Component {
         )}
       >
         <li>
+          <div className={Styles.ReportingReport__outcome_selection_msg}>
+            Please choose an outcome below based on the resolution source at the
+            time the market ended. The market should be considered invalid if it
+            is opinion-based, unclear, has more than one valid outcome, or the
+            outcome wasn&#39;t known when the market ended.
+          </div>
+        </li>
+        <li>
           <label>
             <span>Outcome</span>
           </label>

--- a/src/modules/reporting/components/reporting-report-form/reporting-report-form.styles.less
+++ b/src/modules/reporting/components/reporting-report-form/reporting-report-form.styles.less
@@ -30,3 +30,11 @@ ul.ReportingReportForm__fields {
   text-transform: none;
   white-space: nowrap;
 }
+
+.ReportingReport__outcome_selection_msg {
+  color: @color-white;
+  font-size: 1rem;
+  line-height: 1rem;
+  position: relative;
+  top: 0.25rem;
+}


### PR DESCRIPTION
Fixes https://github.com/AugurProject/augur/issues/594. 

I separated out adding a description of invalid markets on the forking migration & trading pages (https://github.com/AugurProject/augur/issues/795) since creating these tooltips is not as essential or quick as adding a paragraph to the reporting/dispute pages.  I'll work on the tooltips next week, but I wanted to get this change merged in now since we're hoping to have chwy be able to start testing on Monday morning.