### PR TITLE
Fix dispute lockup

### DIFF
--- a/src/modules/create-market/components/create-market-form-resolution/create-market-form-resolution.jsx
+++ b/src/modules/create-market/components/create-market-form-resolution/create-market-form-resolution.jsx
@@ -356,9 +356,12 @@ export default class CreateMarketResolution extends Component {
           <br />
           <p>
             {" "}
-            This should be a date &amp; time sufficiently *after* the event, when the result can be viewed publicly.
+            This should be a date &amp; time sufficiently *after* the event,
+            when the result can be viewed publicly.
             <br />
-            If an event happens on 01/01 and is reported on 01/02, the expiration date should be after the time it&apos;s reported on 01/02.{" "}
+            If an event happens on 01/01 and is reported on 01/02, the
+            expiration date should be after the time it&apos;s reported on
+            01/02.{" "}
           </p>
           <br />
           <SingleDatePicker

--- a/src/modules/markets-list/components/markets-list.jsx
+++ b/src/modules/markets-list/components/markets-list.jsx
@@ -55,7 +55,8 @@ export default class MarketsList extends Component {
       lowerBound: 1,
       boundedLength: 10,
       marketIdsMissingInfo: [], // This is ONLY the currently displayed markets that are missing info
-      showPagination: props.filteredMarkets.length > PAGINATION_COUNT
+      showPagination:
+        props.filteredMarkets && props.filteredMarkets.length > PAGINATION_COUNT
     };
 
     this.setSegment = this.setSegment.bind(this);
@@ -139,7 +140,7 @@ export default class MarketsList extends Component {
     } = this.props;
     const s = this.state;
 
-    const marketsLength = filteredMarkets.length;
+    const marketsLength = (filteredMarkets || []).length;
 
     return (
       <article className="markets-list" data-testid={testid} style={style}>

--- a/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
+++ b/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
@@ -38,7 +38,10 @@ export default class PortfolioReports extends Component {
     resolvedMarkets: PropTypes.array.isRequired,
     toggleFavorite: PropTypes.func.isRequired,
     loadMarketsInfoIfNotLoaded: PropTypes.func.isRequired,
-    loadMarkets: PropTypes.func.isRequired
+    loadMarkets: PropTypes.func.isRequired,
+    disputableMarketIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    upcomingDisputableMarketIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    loadDisputingDetails: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -112,7 +115,10 @@ export default class PortfolioReports extends Component {
       showUpcomingPagination,
       loadMarketsInfoIfNotLoaded,
       resolvedMarkets,
-      toggleFavorite
+      toggleFavorite,
+      disputableMarketIds,
+      upcomingDisputableMarketIds,
+      loadDisputingDetails
     } = this.props;
     let disableClaimReportingFeesNonforkedMarketsButton = "";
     if (
@@ -183,6 +189,9 @@ export default class PortfolioReports extends Component {
             markets={markets}
             upcomingMarkets={upcomingMarkets}
             upcomingMarketsCount={upcomingMarketsCount}
+            disputableMarketIds={disputableMarketIds}
+            upcomingDisputableMarketIds={upcomingDisputableMarketIds}
+            loadDisputingDetails={loadDisputingDetails}
             isMobile={isMobile}
             isConnected={isConnected}
             loadMarkets={loadMarkets}

--- a/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
+++ b/src/modules/portfolio/components/portfolio-reports/portfolio-reports.jsx
@@ -36,6 +36,7 @@ export default class PortfolioReports extends Component {
     updateModal: PropTypes.func.isRequired,
     reportingFees: PropTypes.object.isRequired,
     resolvedMarkets: PropTypes.array.isRequired,
+    resolvedMarketIds: PropTypes.array.isRequired,
     toggleFavorite: PropTypes.func.isRequired,
     loadMarketsInfoIfNotLoaded: PropTypes.func.isRequired,
     loadMarkets: PropTypes.func.isRequired,
@@ -115,6 +116,7 @@ export default class PortfolioReports extends Component {
       showUpcomingPagination,
       loadMarketsInfoIfNotLoaded,
       resolvedMarkets,
+      resolvedMarketIds,
       toggleFavorite,
       disputableMarketIds,
       upcomingDisputableMarketIds,
@@ -209,11 +211,13 @@ export default class PortfolioReports extends Component {
         <div>
           <ReportingResolved
             location={location}
+            isConnected={isConnected}
             history={history}
             isLogged={isConnected}
             isMobile={isMobile}
             loadMarketsInfoIfNotLoaded={loadMarketsInfoIfNotLoaded}
-            markets={resolvedMarkets}
+            resolvedMarkets={resolvedMarkets}
+            resolvedMarketIds={resolvedMarketIds}
             noShowHeader
             toggleFavorite={toggleFavorite}
             nullMessage="Markets you have staked on will be listed here when resolved."

--- a/src/modules/portfolio/containers/reports.js
+++ b/src/modules/portfolio/containers/reports.js
@@ -57,8 +57,8 @@ const mapStateToProps = state => {
     ["desc"]
   );
 
-  const disputableMarketIds = disputableMarkets.map(item => item.id);
-  const resolvedMarketIds = userResolvedMarkets.map(item => item.id);
+  const disputableMarketIds = disputableMarkets.map(item => item.id) || [];
+  const resolvedMarketIds = userResolvedMarkets.map(item => item.id) || [];
   const upcomingDisputableMarketIds = upcomingDisputableMarkets.map(
     item => item.id
   );

--- a/src/modules/portfolio/containers/reports.js
+++ b/src/modules/portfolio/containers/reports.js
@@ -51,9 +51,14 @@ const mapStateToProps = state => {
     }
   });
 
-  orderBy(resolvedMarkets, ["endTime.timestamp"], ["desc"]);
+  const userResolvedMarkets = orderBy(
+    resolvedMarkets,
+    ["endTime.timestamp"],
+    ["desc"]
+  );
 
   const disputableMarketIds = disputableMarkets.map(item => item.id);
+  const resolvedMarketIds = userResolvedMarkets.map(item => item.id);
   const upcomingDisputableMarketIds = upcomingDisputableMarkets.map(
     item => item.id
   );
@@ -73,7 +78,8 @@ const mapStateToProps = state => {
     showUpcomingPagination: upcomingDisputableMarkets.length > PAGINATION_COUNT,
     paginationCount: PAGINATION_COUNT,
     outcomes: disputeOutcomes,
-    resolvedMarkets,
+    resolvedMarkets: userResolvedMarkets,
+    resolvedMarketIds,
     isForking: state.universe.isForking,
     forkEndTime: state.universe.forkEndTime,
     forkingMarketId: state.universe.forkingMarket,

--- a/src/modules/portfolio/containers/reports.js
+++ b/src/modules/portfolio/containers/reports.js
@@ -1,7 +1,7 @@
 import { constants } from "services/augurjs";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
-import { selectCurrentTimestamp, selectMarketReportState } from "src/select-state";
+import { selectCurrentTimestamp } from "src/select-state";
 import { each, orderBy } from "lodash";
 import PortfolioReports from "modules/portfolio/components/portfolio-reports/portfolio-reports";
 import { updateModal } from "modules/modal/actions/update-modal";
@@ -24,9 +24,6 @@ const mapStateToProps = state => {
   const disputableMarkets = [];
   const upcomingDisputableMarkets = [];
   const resolvedMarkets = [];
-  const disputableMarketIds = selectMarketReportState(state).dispute || [];
-  const upcomingDisputableMarketIds =
-    selectMarketReportState(state).awaiting || [];
 
   const reportedMarkets =
     (state.reports &&
@@ -55,6 +52,11 @@ const mapStateToProps = state => {
   });
 
   orderBy(resolvedMarkets, ["endTime.timestamp"], ["desc"]);
+
+  const disputableMarketIds = disputableMarkets.map(item => item.id);
+  const upcomingDisputableMarketIds = upcomingDisputableMarkets.map(
+    item => item.id
+  );
 
   return {
     currentTimestamp: selectCurrentTimestamp(state),

--- a/src/modules/portfolio/containers/reports.js
+++ b/src/modules/portfolio/containers/reports.js
@@ -1,7 +1,7 @@
 import { constants } from "services/augurjs";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
-import { selectCurrentTimestamp } from "src/select-state";
+import { selectCurrentTimestamp, selectMarketReportState } from "src/select-state";
 import { each, orderBy } from "lodash";
 import PortfolioReports from "modules/portfolio/components/portfolio-reports/portfolio-reports";
 import { updateModal } from "modules/modal/actions/update-modal";
@@ -13,6 +13,7 @@ import marketDisputeOutcomes from "modules/reports/selectors/select-market-dispu
 import { loadReportingHistory } from "modules/reports/actions/load-reporting-history";
 import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets-info";
 import { toggleFavorite } from "modules/markets/actions/update-favorites";
+import { loadDisputingDetails } from "modules/reports/actions/load-disputing-details";
 
 const mapStateToProps = state => {
   const PAGINATION_COUNT = 10;
@@ -23,6 +24,9 @@ const mapStateToProps = state => {
   const disputableMarkets = [];
   const upcomingDisputableMarkets = [];
   const resolvedMarkets = [];
+  const disputableMarketIds = selectMarketReportState(state).dispute || [];
+  const upcomingDisputableMarketIds =
+    selectMarketReportState(state).awaiting || [];
 
   const reportedMarkets =
     (state.reports &&
@@ -61,16 +65,18 @@ const mapStateToProps = state => {
     reportingFees: state.reportingWindowStats.reportingFees,
     markets: disputableMarkets,
     showPagination: disputableMarkets.length > PAGINATION_COUNT,
-    disputableMarketsLength: disputableMarkets.length,
+    disputableMarketsLength: disputableMarketIds.length,
     upcomingMarkets: upcomingDisputableMarkets,
-    upcomingMarketsCount: upcomingDisputableMarkets.length,
+    upcomingMarketsCount: upcomingDisputableMarketIds.length,
     showUpcomingPagination: upcomingDisputableMarkets.length > PAGINATION_COUNT,
     paginationCount: PAGINATION_COUNT,
     outcomes: disputeOutcomes,
     resolvedMarkets,
     isForking: state.universe.isForking,
     forkEndTime: state.universe.forkEndTime,
-    forkingMarketId: state.universe.forkingMarket
+    forkingMarketId: state.universe.forkingMarket,
+    disputableMarketIds,
+    upcomingDisputableMarketIds
   };
 };
 
@@ -82,7 +88,9 @@ const mapDispatchToProps = dispatch => ({
   loadMarkets: () => dispatch(loadReportingHistory()),
   loadMarketsInfoIfNotLoaded: marketIds =>
     dispatch(loadMarketsInfoIfNotLoaded(marketIds)),
-  toggleFavorite: marketId => dispatch(toggleFavorite(marketId))
+  toggleFavorite: marketId => dispatch(toggleFavorite(marketId)),
+  loadDisputingDetails: (marketIds, cb) =>
+    dispatch(loadDisputingDetails(marketIds, cb))
 });
 
 export default withRouter(

--- a/src/modules/reporting/components/common/disputing-markets.jsx
+++ b/src/modules/reporting/components/common/disputing-markets.jsx
@@ -168,7 +168,7 @@ export default class DisputingMarkets extends Component {
       upcomingMarkets,
       lowerBoundUpcoming,
       boundedLengthUpcoming,
-      showPagination
+      showUpcomingPagination
     );
     if (isForking) {
       forkingMarket = markets.find(market => market.id === forkingMarketId);

--- a/src/modules/reporting/components/common/disputing-markets.jsx
+++ b/src/modules/reporting/components/common/disputing-markets.jsx
@@ -5,7 +5,6 @@ import NullStateMessage from "modules/common/components/null-state-message/null-
 import DisputeMarketCard from "modules/reporting/components/dispute-market-card/dispute-market-card";
 import Paginator from "modules/common/components/paginator/paginator";
 import MarketsHeaderLabel from "modules/markets-list/components/markets-header-label/markets-header-label";
-import isEqual from "lodash/isEqual";
 
 export default class DisputingMarkets extends Component {
   static propTypes = {
@@ -26,7 +25,10 @@ export default class DisputingMarkets extends Component {
     loadMarkets: PropTypes.func.isRequired,
     nullDisputeMessage: PropTypes.string,
     nullUpcomingMessage: PropTypes.string,
-    addNullPadding: PropTypes.bool
+    addNullPadding: PropTypes.bool,
+    disputableMarketIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    upcomingDisputableMarketIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    loadDisputingDetails: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -44,11 +46,7 @@ export default class DisputingMarkets extends Component {
       lowerBound: 1,
       boundedLength: paginationCount,
       lowerBoundUpcoming: 1,
-      boundedLengthUpcoming: paginationCount,
-      loadedMarkets: [],
-      filteredMarkets: [],
-      loadedUpcomingMarkets: [],
-      filteredUpcomingMarkets: []
+      boundedLengthUpcoming: paginationCount
     };
 
     this.setSegment = this.setSegment.bind(this);
@@ -57,7 +55,9 @@ export default class DisputingMarkets extends Component {
 
   componentWillMount() {
     const { loadMarkets, isConnected } = this.props;
-    if (loadMarkets && isConnected) loadMarkets();
+    if (loadMarkets && isConnected) {
+      loadMarkets();
+    }
   }
 
   componentWillUpdate(nextProps, nextState) {
@@ -65,42 +65,41 @@ export default class DisputingMarkets extends Component {
       this.props.loadMarkets();
     if (
       this.state.lowerBound !== nextState.lowerBound ||
-      this.state.boundedLength !== nextState.boundedLength ||
-      !isEqual(this.state.loadedMarkets, nextProps.markets)
+      this.state.boundedLength !== nextState.boundedLength
     ) {
-      this.setLoadedMarkets(
-        nextProps.markets,
+      this.loadDisputingMarkets(
+        this.props.disputableMarketIds,
         nextState.lowerBound,
-        nextState.boundedLength,
-        nextProps.showPagination
+        nextState.boundedLength
       );
     }
     if (
       this.state.lowerBoundUpcoming !== nextState.lowerBoundUpcoming ||
-      this.state.boundedLengthUpcoming !== nextState.boundedLengthUpcoming ||
-      !isEqual(this.state.loadedUpcomingMarkets, nextProps.upcomingMarkets)
+      this.state.boundedLengthUpcoming !== nextState.boundedLengthUpcoming
     ) {
-      this.setLoadedMarketsUpcoming(
-        nextProps.upcomingMarkets,
+      this.loadDisputingMarkets(
+        this.props.upcomingDisputableMarketIds,
         nextState.lowerBoundUpcoming,
-        nextState.boundedLengthUpcoming,
-        nextProps.showUpcomingPagination
+        nextState.boundedLengthUpcoming
       );
     }
-  }
-
-  setLoadedMarkets(markets, lowerBound, boundedLength, showPagination) {
-    const filteredMarkets =
-      this.filterMarkets(markets, lowerBound, boundedLength, showPagination) ||
-      [];
-    this.setState({ filteredMarkets, loadedMarkets: markets });
-  }
-
-  setLoadedMarketsUpcoming(markets, lowerBound, boundedLength, showPagination) {
-    const filteredUpcomingMarkets =
-      this.filterMarkets(markets, lowerBound, boundedLength, showPagination) ||
-      [];
-    this.setState({ filteredUpcomingMarkets, loadedUpcomingMarkets: markets });
+    if (this.props.disputableMarketIds !== nextProps.disputableMarketIds) {
+      this.loadDisputingMarkets(
+        nextProps.disputableMarketIds,
+        nextState.lowerBound,
+        nextState.boundedLength
+      );
+    }
+    if (
+      this.props.upcomingDisputableMarketIds !==
+      nextProps.upcomingDisputableMarketIds
+    ) {
+      this.loadDisputingMarkets(
+        nextProps.upcomingDisputableMarketIds,
+        nextState.lowerBoundUpcoming,
+        nextState.boundedLengthUpcoming
+      );
+    }
   }
 
   setSegment(lowerBound, upperBound, boundedLength) {
@@ -109,6 +108,13 @@ export default class DisputingMarkets extends Component {
 
   setSegmentUpcoming(lowerBoundUpcoming, upperBound, boundedLengthUpcoming) {
     this.setState({ lowerBoundUpcoming, boundedLengthUpcoming });
+  }
+
+  loadDisputingMarkets(marketIds, lowerBound, boundedLength) {
+    const { loadDisputingDetails } = this.props;
+    const marketIdLength = boundedLength + (lowerBound - 1);
+    const newMarketIdArray = marketIds.slice(lowerBound - 1, marketIdLength);
+    loadDisputingDetails([...newMarketIdArray]);
   }
 
   filterMarkets(markets, lowerBound, boundedLength, showPagination) {
@@ -122,6 +128,7 @@ export default class DisputingMarkets extends Component {
         ? markets.filter(m => newMarketIdArray.indexOf(m.id) !== -1)
         : markets;
     }
+    return [];
   }
 
   render() {
@@ -132,6 +139,7 @@ export default class DisputingMarkets extends Component {
       location,
       markets,
       outcomes,
+      upcomingMarkets,
       upcomingMarketsCount,
       forkingMarketId,
       paginationCount,
@@ -142,17 +150,33 @@ export default class DisputingMarkets extends Component {
       nullUpcomingMessage,
       addNullPadding
     } = this.props;
-    const { filteredMarkets, filteredUpcomingMarkets } = this.state;
+    const {
+      lowerBound,
+      boundedLength,
+      lowerBoundUpcoming,
+      boundedLengthUpcoming
+    } = this.state;
 
     let forkingMarket = null;
-    let nonForkingMarkets = filteredMarkets;
+    let nonForkingMarkets = this.filterMarkets(
+      markets,
+      lowerBound,
+      boundedLength,
+      showPagination
+    );
+    const filteredUpcomingMarkets = this.filterMarkets(
+      upcomingMarkets,
+      lowerBoundUpcoming,
+      boundedLengthUpcoming,
+      showPagination
+    );
     if (isForking) {
       forkingMarket = markets.find(market => market.id === forkingMarketId);
-      nonForkingMarkets = filteredMarkets.filter(
+      nonForkingMarkets = nonForkingMarkets.filter(
         market => market.id !== forkingMarketId
       );
     }
-    const nonForkingMarketsCount = filteredMarkets.length;
+    const nonForkingMarketsCount = nonForkingMarkets.length;
 
     return (
       <section>

--- a/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
+++ b/src/modules/reporting/components/reporting-dispute-markets/reporting-dispute-markets.jsx
@@ -27,7 +27,10 @@ export default class ReportingDisputeMarkets extends Component {
     disputableMarketsLength: PropTypes.number.isRequired,
     forkEndTime: PropTypes.string,
     showPagination: PropTypes.bool.isRequired,
-    showUpcomingPagination: PropTypes.bool.isRequired
+    showUpcomingPagination: PropTypes.bool.isRequired,
+    disputableMarketIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    upcomingDisputableMarketIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    loadDisputingDetails: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -60,7 +63,10 @@ export default class ReportingDisputeMarkets extends Component {
       paginationCount,
       disputableMarketsLength,
       showPagination,
-      showUpcomingPagination
+      showUpcomingPagination,
+      disputableMarketIds,
+      upcomingDisputableMarketIds,
+      loadDisputingDetails
     } = this.props;
 
     return (
@@ -89,6 +95,9 @@ export default class ReportingDisputeMarkets extends Component {
           markets={markets}
           upcomingMarkets={upcomingMarkets}
           upcomingMarketsCount={upcomingMarketsCount}
+          disputableMarketIds={disputableMarketIds}
+          upcomingDisputableMarketIds={upcomingDisputableMarketIds}
+          loadDisputingDetails={loadDisputingDetails}
           isMobile={isMobile}
           isConnected={isConnected}
           loadMarkets={loadMarkets}

--- a/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
+++ b/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
@@ -16,8 +16,8 @@ export default class ReportingResolved extends Component {
   static propTypes = {
     location: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
-    markets: PropTypes.array.isRequired,
-    marketIds: PropTypes.array.isRequired,
+    resolvedMarkets: PropTypes.array.isRequired,
+    resolvedMarketIds: PropTypes.array.isRequired,
     isConnected: PropTypes.bool.isRequired,
     nullMessage: PropTypes.string,
     isLogged: PropTypes.bool.isRequired,
@@ -56,8 +56,8 @@ export default class ReportingResolved extends Component {
       isLogged,
       isMobile,
       loadMarketsInfoIfNotLoaded,
-      markets,
-      marketIds,
+      resolvedMarkets,
+      resolvedMarketIds,
       toggleFavorite,
       isForkingMarketFinalized,
       forkingMarket,
@@ -91,8 +91,8 @@ export default class ReportingResolved extends Component {
         <MarketsList
           isLogged={isLogged}
           isMobile={isMobile}
-          markets={markets}
-          filteredMarkets={marketIds}
+          markets={resolvedMarkets}
+          filteredMarkets={resolvedMarketIds}
           location={location}
           history={history}
           linkType={TYPE_FINALIZE_MARKET}

--- a/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
+++ b/src/modules/reporting/components/reporting-resolved/reporting-resolved.jsx
@@ -12,21 +12,13 @@ import DisputeMarketCard from "modules/reporting/components/dispute-market-card/
 import Styles from "modules/reporting/components/reporting-resolved/reporting-resolved.styles";
 import MarketsHeaderLabel from "modules/markets-list/components/markets-header-label/markets-header-label";
 
-function getMarketIds(markets) {
-  const filteredMarkets = [];
-  markets.forEach(market => {
-    filteredMarkets.push(market.id);
-  });
-  // Reverse order of filteredMarkets so markets resolved most recently are first
-  filteredMarkets.reverse();
-  return filteredMarkets;
-}
-
 export default class ReportingResolved extends Component {
   static propTypes = {
     location: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     markets: PropTypes.array.isRequired,
+    marketIds: PropTypes.array.isRequired,
+    isConnected: PropTypes.bool.isRequired,
     nullMessage: PropTypes.string,
     isLogged: PropTypes.bool.isRequired,
     loadMarketsInfoIfNotLoaded: PropTypes.func.isRequired,
@@ -48,24 +40,14 @@ export default class ReportingResolved extends Component {
     showOutstandingReturns: false
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      filteredMarkets: []
-    };
-  }
-
   componentWillMount() {
-    const { loadReporting } = this.props;
-    if (loadReporting) loadReporting();
+    const { loadReporting, isConnected } = this.props;
+    if (loadReporting && isConnected) loadReporting();
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { markets } = this.props;
-    if (nextProps.markets.length > 0 && nextProps.markets !== markets) {
-      const filteredMarkets = getMarketIds(nextProps.markets);
-      this.setState({ filteredMarkets });
+  componentWillUpdate(nextProps, nextState) {
+    if (this.props.isConnected !== nextProps.isConnected) {
+      this.props.loadReporting();
     }
   }
 
@@ -75,6 +57,7 @@ export default class ReportingResolved extends Component {
       isMobile,
       loadMarketsInfoIfNotLoaded,
       markets,
+      marketIds,
       toggleFavorite,
       isForkingMarketFinalized,
       forkingMarket,
@@ -84,7 +67,6 @@ export default class ReportingResolved extends Component {
       history,
       showOutstandingReturns
     } = this.props;
-    const s = this.state;
 
     return (
       <section>
@@ -110,7 +92,7 @@ export default class ReportingResolved extends Component {
           isLogged={isLogged}
           isMobile={isMobile}
           markets={markets}
-          filteredMarkets={s.filteredMarkets}
+          filteredMarkets={marketIds}
           location={location}
           history={history}
           linkType={TYPE_FINALIZE_MARKET}

--- a/src/modules/reporting/containers/reporting-dispute-markets.js
+++ b/src/modules/reporting/containers/reporting-dispute-markets.js
@@ -5,9 +5,11 @@ import ReportingDisputeMarkets from "modules/reporting/components/reporting-disp
 import makePath from "modules/routes/helpers/make-path";
 import { ACCOUNT_DEPOSIT } from "modules/routes/constants/views";
 import { selectLoginAccount } from "modules/auth/selectors/login-account";
+import { selectMarketReportState } from "src/select-state";
 import { selectMarketsInDispute } from "modules/reports/selectors/select-dispute-markets";
 import awaitingDisputeMarkets from "modules/reports/selectors/select-awaiting-dispute-markets";
 import { loadDisputing } from "modules/reports/actions/load-disputing";
+import { loadDisputingDetails } from "modules/reports/actions/load-disputing-details";
 import marketDisputeOutcomes from "modules/reports/selectors/select-market-dispute-outcomes";
 
 const mapStateToProps = (state, { history }) => {
@@ -16,30 +18,38 @@ const mapStateToProps = (state, { history }) => {
   const disputeOutcomes = marketDisputeOutcomes() || {};
   const disputableMarkets = selectMarketsInDispute(state) || [];
   const upcomingDisputableMarkets = awaitingDisputeMarkets() || [];
+  const disputableMarketIds = selectMarketReportState(state).dispute || [];
+  const upcomingDisputableMarketIds =
+    selectMarketReportState(state).awaiting || [];
   const { isForking, forkEndTime, forkingMarket, id } = state.universe;
   return {
     isLogged: state.authStatus.isLogged,
     isConnected: state.connection.isConnected && id != null,
     doesUserHaveRep: loginAccount.rep.value > 0 || !state.authStatus.isLogged,
     markets: disputableMarkets,
-    showPagination: disputableMarkets.length > PAGINATION_COUNT,
-    disputableMarketsLength: disputableMarkets.length,
+    showPagination: disputableMarketIds.length > PAGINATION_COUNT,
+    disputableMarketsLength: disputableMarketIds.length,
     paginationCount: PAGINATION_COUNT,
     upcomingMarkets: upcomingDisputableMarkets,
-    upcomingMarketsCount: upcomingDisputableMarkets.length,
-    showUpcomingPagination: upcomingDisputableMarkets.length > PAGINATION_COUNT,
+    upcomingMarketsCount: upcomingDisputableMarketIds.length,
+    showUpcomingPagination:
+      upcomingDisputableMarketIds.length > PAGINATION_COUNT,
     isMobile: state.appStatus.isMobile,
     navigateToAccountDepositHandler: () =>
       history.push(makePath(ACCOUNT_DEPOSIT)),
     outcomes: disputeOutcomes,
     isForking,
     forkEndTime,
-    forkingMarketId: forkingMarket
+    forkingMarketId: forkingMarket,
+    disputableMarketIds,
+    upcomingDisputableMarketIds
   };
 };
 
 const mapDispatchToProps = dispatch => ({
-  loadMarkets: () => dispatch(loadDisputing())
+  loadMarkets: () => dispatch(loadDisputing()),
+  loadDisputingDetails: (marketIds, cb) =>
+    dispatch(loadDisputingDetails(marketIds, cb))
 });
 
 const ReportingDisputeContainer = connect(

--- a/src/modules/reporting/containers/reporting-report-markets.js
+++ b/src/modules/reporting/containers/reporting-report-markets.js
@@ -1,15 +1,20 @@
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
-
 import ReportingReportMarkets from "modules/reporting/components/reporting-report-markets/reporting-report-markets";
 import { loadReporting } from "modules/reports/actions/load-reporting";
 import { selectMarketsToReport } from "modules/reports/selectors/select-markets-to-report";
+import { selectMarkets } from "src/modules/markets/selectors/markets-all";
 
-const mapStateToProps = state => ({
-  isLogged: state.authStatus.isLogged,
-  markets: selectMarketsToReport(state),
-  universe: state.universe.id
-});
+const mapStateToProps = state => {
+  const marketsData = selectMarkets(state);
+  const markets = selectMarketsToReport(marketsData);
+
+  return {
+    isLogged: state.authStatus.isLogged,
+    markets,
+    universe: state.universe.id
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
   loadReporting: () => dispatch(loadReporting())

--- a/src/modules/reporting/containers/reporting-resolved.js
+++ b/src/modules/reporting/containers/reporting-resolved.js
@@ -2,7 +2,7 @@ import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 
 import ReportingResolved from "modules/reporting/components/reporting-resolved/reporting-resolved";
-import { loadReporting } from "src/modules/reports/actions/load-reporting";
+import { loadReportingFinal } from "src/modules/reports/actions/load-reporting-final";
 import { selectMarketsToReport } from "modules/reports/selectors/select-markets-to-report";
 import { toggleFavorite } from "modules/markets/actions/update-favorites";
 import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets-info";
@@ -21,7 +21,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  loadReporting: () => dispatch(loadReporting()),
+  loadReporting: () => dispatch(loadReportingFinal()),
   loadMarketsInfoIfNotLoaded: marketIds =>
     dispatch(loadMarketsInfoIfNotLoaded(marketIds)),
   toggleFavorite: marketId => dispatch(toggleFavorite(marketId))

--- a/src/modules/reporting/containers/reporting-resolved.js
+++ b/src/modules/reporting/containers/reporting-resolved.js
@@ -1,24 +1,35 @@
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
-
+import { constants } from "services/augurjs";
 import ReportingResolved from "modules/reporting/components/reporting-resolved/reporting-resolved";
+import { selectMarketReportState } from "src/select-state";
 import { loadReportingFinal } from "src/modules/reports/actions/load-reporting-final";
-import { selectMarketsToReport } from "modules/reports/selectors/select-markets-to-report";
 import { toggleFavorite } from "modules/markets/actions/update-favorites";
 import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets-info";
-
-import getValue from "utils/get-value";
+import { selectMarkets } from "src/modules/markets/selectors/markets-all";
 import { selectMarket } from "modules/markets/selectors/market";
 
-const mapStateToProps = state => ({
-  isLogged: state.authStatus.isLogged,
-  isMobile: state.appStatus.isMobile,
-  markets: getValue(selectMarketsToReport(state), "resolved"),
-  isForkingMarketFinalized: state.universe.isForkingMarketFinalized,
-  forkingMarket: state.universe.isForking
-    ? selectMarket(state.universe.forkingMarket)
-    : null
-});
+const mapStateToProps = state => {
+  const marketsData = selectMarkets(state);
+  const markets = marketsData.filter(
+    market =>
+      market.reportingState === constants.REPORTING_STATE.FINALIZED ||
+      market.reportingState === constants.REPORTING_STATE.AWAITING_FINALIZATION
+  );
+  const marketIds = selectMarketReportState(state).resolved || [];
+
+  return {
+    isConnected: !!state.universe.id,
+    isLogged: state.authStatus.isLogged,
+    isMobile: state.appStatus.isMobile,
+    markets,
+    marketIds,
+    isForkingMarketFinalized: state.universe.isForkingMarketFinalized,
+    forkingMarket: state.universe.isForking
+      ? selectMarket(state.universe.forkingMarket)
+      : null
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
   loadReporting: () => dispatch(loadReportingFinal()),

--- a/src/modules/reporting/containers/reporting-resolved.js
+++ b/src/modules/reporting/containers/reporting-resolved.js
@@ -11,19 +11,19 @@ import { selectMarket } from "modules/markets/selectors/market";
 
 const mapStateToProps = state => {
   const marketsData = selectMarkets(state);
-  const markets = marketsData.filter(
+  const resolvedMarkets = marketsData.filter(
     market =>
       market.reportingState === constants.REPORTING_STATE.FINALIZED ||
       market.reportingState === constants.REPORTING_STATE.AWAITING_FINALIZATION
   );
-  const marketIds = selectMarketReportState(state).resolved || [];
+  const resolvedMarketIds = selectMarketReportState(state).resolved || [];
 
   return {
     isConnected: !!state.universe.id,
     isLogged: state.authStatus.isLogged,
     isMobile: state.appStatus.isMobile,
-    markets,
-    marketIds,
+    resolvedMarkets,
+    resolvedMarketIds,
     isForkingMarketFinalized: state.universe.isForkingMarketFinalized,
     forkingMarket: state.universe.isForking
       ? selectMarket(state.universe.forkingMarket)

--- a/src/modules/reports/actions/load-disputing-details.js
+++ b/src/modules/reports/actions/load-disputing-details.js
@@ -1,0 +1,15 @@
+import logError from "src/utils/log-error";
+import {
+  loadMarketsInfoIfNotLoaded,
+  loadMarketsDisputeInfo
+} from "modules/markets/actions/load-markets-info";
+
+export const loadDisputingDetails = (
+  marketIds,
+  callback = logError
+) => dispatch => {
+  dispatch(loadMarketsInfoIfNotLoaded(marketIds));
+  dispatch(loadMarketsDisputeInfo(marketIds), () => {
+    callback(null);
+  });
+};

--- a/src/modules/reports/actions/load-disputing.js
+++ b/src/modules/reports/actions/load-disputing.js
@@ -9,6 +9,8 @@ import async from "async";
 export const loadDisputing = (callback = logError) => (dispatch, getState) => {
   const { universe } = getState();
   const args = {
+    sortBy: "endTime",
+    isSortDescending: true,
     universe: universe.id
   };
   async.parallel(
@@ -18,7 +20,6 @@ export const loadDisputing = (callback = logError) => (dispatch, getState) => {
           "getMarkets",
           {
             reportingState: constants.REPORTING_STATE.CROWDSOURCING_DISPUTE,
-            sortBy: "endTime",
             ...args
           },
           (err, result) => {
@@ -33,7 +34,6 @@ export const loadDisputing = (callback = logError) => (dispatch, getState) => {
           "getMarkets",
           {
             reportingState: constants.REPORTING_STATE.AWAITING_NEXT_WINDOW,
-            sortBy: "endTime",
             ...args
           },
           (err, result) => {

--- a/src/modules/reports/actions/load-disputing.js
+++ b/src/modules/reports/actions/load-disputing.js
@@ -10,7 +10,7 @@ export const loadDisputing = (callback = logError) => (dispatch, getState) => {
   const { universe } = getState();
   const args = {
     sortBy: "endTime",
-    isSortDescending: true,
+    isSortDescending: false,
     universe: universe.id
   };
   async.parallel(

--- a/src/modules/reports/actions/load-disputing.js
+++ b/src/modules/reports/actions/load-disputing.js
@@ -1,49 +1,51 @@
 import { augur, constants } from "services/augurjs";
 import logError from "src/utils/log-error";
 import {
-  loadMarketsInfoIfNotLoaded,
-  loadMarketsDisputeInfo
-} from "modules/markets/actions/load-markets-info";
-import {
   updateAwaitingDisputeMarkets,
   updateCrowdDisputeMarkets
 } from "modules/reports/actions/update-markets-in-reporting-state";
+import async from "async";
 
 export const loadDisputing = (callback = logError) => (dispatch, getState) => {
   const { universe } = getState();
   const args = {
     universe: universe.id
   };
+  async.parallel(
+    [
+      next =>
+        augur.augurNode.submitRequest(
+          "getMarkets",
+          {
+            reportingState: constants.REPORTING_STATE.CROWDSOURCING_DISPUTE,
+            sortBy: "endTime",
+            ...args
+          },
+          (err, result) => {
+            if (err) return next(err);
 
-  augur.augurNode.submitRequest(
-    "getMarkets",
-    {
-      reportingState: constants.REPORTING_STATE.CROWDSOURCING_DISPUTE,
-      sortBy: "endTime",
-      ...args
-    },
-    (err, result) => {
-      if (err) return callback(err);
-
-      dispatch(loadMarketsInfoIfNotLoaded(result));
-      dispatch(updateCrowdDisputeMarkets(result));
-      dispatch(loadMarketsDisputeInfo(result));
-    }
-  );
-
-  augur.augurNode.submitRequest(
-    "getMarkets",
-    {
-      reportingState: constants.REPORTING_STATE.AWAITING_NEXT_WINDOW,
-      sortBy: "endTime",
-      ...args
-    },
-    (err, result) => {
-      if (err) return callback(err);
-
-      dispatch(loadMarketsInfoIfNotLoaded(result));
-      dispatch(updateAwaitingDisputeMarkets(result));
-      dispatch(loadMarketsDisputeInfo(result));
+            dispatch(updateCrowdDisputeMarkets(result));
+            next(null);
+          }
+        ),
+      next =>
+        augur.augurNode.submitRequest(
+          "getMarkets",
+          {
+            reportingState: constants.REPORTING_STATE.AWAITING_NEXT_WINDOW,
+            sortBy: "endTime",
+            ...args
+          },
+          (err, result) => {
+            if (err) return next(err);
+            dispatch(updateAwaitingDisputeMarkets(result));
+            next(null);
+          }
+        )
+    ],
+    err => {
+      if (err) callback(err);
+      callback(null);
     }
   );
 };

--- a/src/modules/reports/actions/load-disputing.test.js
+++ b/src/modules/reports/actions/load-disputing.test.js
@@ -2,7 +2,7 @@ import configureMockStore from "redux-mock-store";
 
 import thunk from "redux-thunk";
 
-import { augur, constants } from "services/augurjs";
+import { augur } from "services/augurjs";
 
 import { loadDisputing } from "modules/reports/actions/load-disputing";
 
@@ -21,11 +21,6 @@ describe("loadDisputing action", () => {
     universe: {
       id: universeAddress
     }
-  };
-
-  const expectedParams = {
-    sortBy: "endTime",
-    universe: universeAddress
   };
 
   let mockStore;

--- a/src/modules/reports/actions/load-disputing.test.js
+++ b/src/modules/reports/actions/load-disputing.test.js
@@ -43,35 +43,6 @@ describe("loadDisputing action", () => {
     store = mockStore(initialStoreState);
   });
 
-  test("should load upcoming dispute markets for a given user in side the given universe", () => {
-    store.dispatch(loadDisputing());
-
-    expect(augur.augurNode.submitRequest).toHaveBeenNthCalledWith(
-      1,
-      "getMarkets",
-      {
-        reportingState: constants.REPORTING_STATE.CROWDSOURCING_DISPUTE,
-        ...expectedParams
-      },
-      expect.any(Function)
-    );
-    augur.augurNode.submitRequest.mock.calls[0][2](null, ["1111"]);
-
-    expect(augur.augurNode.submitRequest).toHaveBeenNthCalledWith(
-      2,
-      "getMarkets",
-      {
-        reportingState: constants.REPORTING_STATE.AWAITING_NEXT_WINDOW,
-        ...expectedParams
-      },
-      expect.any(Function)
-    );
-    augur.augurNode.submitRequest.mock.calls[0][2](null, ["2222", "3333"]);
-
-    const actual = store.getActions();
-    expect(actual).toHaveLength(2);
-  });
-
   describe("upon error", () => {
     let callback;
     let error;

--- a/src/modules/reports/actions/load-reporting-final.js
+++ b/src/modules/reports/actions/load-reporting-final.js
@@ -1,0 +1,53 @@
+import { augur, constants } from "services/augurjs";
+import logError from "utils/log-error";
+import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets-info";
+
+import { updateResolvedMarkets } from "modules/reports/actions/update-markets-in-reporting-state";
+
+export const loadReportingFinal = (callback = logError) => (
+  dispatch,
+  getState
+) => {
+  const { universe } = getState();
+
+  augur.augurNode.submitRequest(
+    "getMarkets",
+    {
+      reportingState: constants.REPORTING_STATE.FINALIZED,
+      sortBy: "finalizationBlockNumber",
+      isSortDescending: true,
+      universe: universe.id
+    },
+    (err, finalizedMarketIds) => {
+      if (err) return callback(err);
+
+      augur.augurNode.submitRequest(
+        "getMarkets",
+        {
+          reportingState: constants.REPORTING_STATE.AWAITING_FINALIZATION,
+          sortBy: "endTime",
+          isSortDescending: true,
+          universe: universe.id
+        },
+        (err, awaitingFinalizationMarketIds) => {
+          if (err) return callback(err);
+
+          const marketIds = awaitingFinalizationMarketIds.concat(
+            finalizedMarketIds
+          );
+          if (!marketIds || marketIds.length === 0) {
+            dispatch(updateResolvedMarkets([]));
+            return callback(null);
+          }
+
+          dispatch(
+            loadMarketsInfoIfNotLoaded(marketIds, (err, marketData) => {
+              if (err) return logError(err);
+              dispatch(updateResolvedMarkets(marketIds));
+            })
+          );
+        }
+      );
+    }
+  );
+};

--- a/src/modules/reports/actions/load-reporting-final.js
+++ b/src/modules/reports/actions/load-reporting-final.js
@@ -1,7 +1,5 @@
 import { augur, constants } from "services/augurjs";
 import logError from "utils/log-error";
-import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets-info";
-
 import { updateResolvedMarkets } from "modules/reports/actions/update-markets-in-reporting-state";
 
 export const loadReportingFinal = (callback = logError) => (
@@ -40,12 +38,8 @@ export const loadReportingFinal = (callback = logError) => (
             return callback(null);
           }
 
-          dispatch(
-            loadMarketsInfoIfNotLoaded(marketIds, (err, marketData) => {
-              if (err) return logError(err);
-              dispatch(updateResolvedMarkets(marketIds));
-            })
-          );
+          dispatch(updateResolvedMarkets(marketIds));
+          callback(null, marketIds);
         }
       );
     }

--- a/src/modules/reports/actions/load-reporting.js
+++ b/src/modules/reports/actions/load-reporting.js
@@ -5,8 +5,7 @@ import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets
 import {
   updateDesignatedReportingMarkets,
   updateUpcomingDesignatedReportingMarkets,
-  updateOpenMarkets,
-  updateResolvedMarkets
+  updateOpenMarkets
 } from "modules/reports/actions/update-markets-in-reporting-state";
 
 export const loadReporting = (callback = logError) => (dispatch, getState) => {
@@ -80,47 +79,6 @@ export const loadReporting = (callback = logError) => (dispatch, getState) => {
           if (err) return logError(err);
           dispatch(updateOpenMarkets(marketIds));
         })
-      );
-    }
-  );
-
-  augur.augurNode.submitRequest(
-    "getMarkets",
-    {
-      reportingState: constants.REPORTING_STATE.FINALIZED,
-      sortBy: "finalizationBlockNumber",
-      isSortDescending: true,
-      universe: universe.id
-    },
-    (err, finalizedMarketIds) => {
-      if (err) return callback(err);
-
-      augur.augurNode.submitRequest(
-        "getMarkets",
-        {
-          reportingState: constants.REPORTING_STATE.AWAITING_FINALIZATION,
-          sortBy: "endTime",
-          isSortDescending: true,
-          universe: universe.id
-        },
-        (err, awaitingFinalizationMarketIds) => {
-          if (err) return callback(err);
-
-          const marketIds = awaitingFinalizationMarketIds.concat(
-            finalizedMarketIds
-          );
-          if (!marketIds || marketIds.length === 0) {
-            dispatch(updateResolvedMarkets([]));
-            return callback(null);
-          }
-
-          dispatch(
-            loadMarketsInfoIfNotLoaded(marketIds, (err, marketData) => {
-              if (err) return logError(err);
-              dispatch(updateResolvedMarkets(marketIds));
-            })
-          );
-        }
       );
     }
   );

--- a/src/modules/reports/selectors/select-markets-to-report.js
+++ b/src/modules/reports/selectors/select-markets-to-report.js
@@ -1,7 +1,5 @@
-import { createSelector } from "reselect";
 import store from "src/store";
-import { selectMarketReportState } from "src/select-state";
-import { selectMarket } from "modules/markets/selectors/market";
+import { constants } from "services/augurjs";
 
 function filterForkedMarket(market) {
   const { universe } = store.getState();
@@ -12,21 +10,27 @@ function filterForkedMarket(market) {
   );
 }
 
-export const selectMarketsToReport = createSelector(
-  selectMarketReportState,
-  reportData => ({
-    designated: reportData.designated
-      .map(selectMarket)
-      .sort((a, b) => a.endTime.timestamp - b.endTime.timestamp),
-    open: reportData.open
-      .map(selectMarket)
-      .sort((a, b) => a.endTime.timestamp - b.endTime.timestamp),
-    upcoming: reportData.upcoming
-      .map(selectMarket)
-      .sort((a, b) => a.endTime.timestamp - b.endTime.timestamp),
-    resolved: reportData.resolved
-      .map(selectMarket)
-      .filter(filterForkedMarket)
-      .sort((a, b) => a.endTime.timestamp - b.endTime.timestamp)
-  })
-);
+export const selectMarketsToReport = marketsData => {
+  const markets = {};
+  markets.designated = marketsData
+    .filter(
+      market =>
+        market.reportingState === constants.REPORTING_STATE.DESIGNATED_REPORTING
+    )
+    .sort((a, b) => (a.endTime || {}).timestamp - (b.endTime || {}).timestamp);
+  markets.open = marketsData
+    .filter(
+      market =>
+        market.reportingState === constants.REPORTING_STATE.OPEN_REPORTING
+    )
+    .sort((a, b) => (a.endTime || {}).timestamp - (b.endTime || {}).timestamp);
+  markets.upcoming = marketsData
+    .filter(
+      market =>
+        market.reportingState === constants.REPORTING_STATE.PRE_REPORTING &&
+        filterForkedMarket(market)
+    )
+    .sort((a, b) => (a.endTime || {}).timestamp - (b.endTime || {}).timestamp);
+
+  return markets;
+};


### PR DESCRIPTION
fixes https://github.com/AugurProject/augur/issues/779

lazy load dispute markets. Issue was when user lands on disputing page all markets in dispute would be loaded when there are 100s this can take a really long time and appears to be locked up.