### PR TITLE
give outstanding returns a default value rather than make it required

### DIFF
--- a/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card-footer.jsx
+++ b/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card-footer.jsx
@@ -130,7 +130,7 @@ MarketPortfolioCardFooter.propTypes = {
   linkType: PropTypes.string.isRequired,
   localButtonText: PropTypes.string.isRequired,
   buttonAction: PropTypes.func.isRequired,
-  outstandingReturns: PropTypes.string.isRequired,
+  outstandingReturns: PropTypes.string,
   finalizationTime: PropTypes.number,
   currentTimestamp: PropTypes.number.isRequired,
   unclaimedForkEth: PropTypes.object,
@@ -145,7 +145,8 @@ MarketPortfolioCardFooter.defaultProps = {
   unclaimedForkRepStaked: null,
   finalizationTime: null,
   claimClicked: false,
-  disabled: false
+  disabled: false,
+  outstandingReturns: "0"
 };
 
 export default MarketPortfolioCardFooter;


### PR DESCRIPTION
fixing https://github.com/AugurProject/augur-app/issues/430


give outstandingReturns default value, this is needed when market finalize button is shown and user doesn't have a winning position.