### PR TITLE
filter dispute markets after loading if not loaded and getting disput…

### DIFF
--- a/src/modules/reporting/components/common/disputing-markets.jsx
+++ b/src/modules/reporting/components/common/disputing-markets.jsx
@@ -46,7 +46,9 @@ export default class DisputingMarkets extends Component {
       lowerBound: 1,
       boundedLength: paginationCount,
       lowerBoundUpcoming: 1,
-      boundedLengthUpcoming: paginationCount
+      boundedLengthUpcoming: paginationCount,
+      filteredNonForkingMarkets: [],
+      filteredUpcomingMarkets: []
     };
 
     this.setSegment = this.setSegment.bind(this);
@@ -70,7 +72,9 @@ export default class DisputingMarkets extends Component {
       this.loadDisputingMarkets(
         this.props.disputableMarketIds,
         nextState.lowerBound,
-        nextState.boundedLength
+        nextState.boundedLength,
+        nextProps.markets,
+        false
       );
     }
     if (
@@ -80,14 +84,18 @@ export default class DisputingMarkets extends Component {
       this.loadDisputingMarkets(
         this.props.upcomingDisputableMarketIds,
         nextState.lowerBoundUpcoming,
-        nextState.boundedLengthUpcoming
+        nextState.boundedLengthUpcoming,
+        nextProps.upcomingMarkets,
+        true
       );
     }
     if (this.props.disputableMarketIds !== nextProps.disputableMarketIds) {
       this.loadDisputingMarkets(
         nextProps.disputableMarketIds,
         nextState.lowerBound,
-        nextState.boundedLength
+        nextState.boundedLength,
+        nextProps.markets,
+        false
       );
     }
     if (
@@ -97,7 +105,9 @@ export default class DisputingMarkets extends Component {
       this.loadDisputingMarkets(
         nextProps.upcomingDisputableMarketIds,
         nextState.lowerBoundUpcoming,
-        nextState.boundedLengthUpcoming
+        nextState.boundedLengthUpcoming,
+        nextProps.upcomingMarkets,
+        true
       );
     }
   }
@@ -110,11 +120,30 @@ export default class DisputingMarkets extends Component {
     this.setState({ lowerBoundUpcoming, boundedLengthUpcoming });
   }
 
-  loadDisputingMarkets(marketIds, lowerBound, boundedLength) {
+  loadDisputingMarkets(
+    marketIds,
+    lowerBound,
+    boundedLength,
+    markets,
+    isUpcoming
+  ) {
     const { loadDisputingDetails } = this.props;
     const marketIdLength = boundedLength + (lowerBound - 1);
     const newMarketIdArray = marketIds.slice(lowerBound - 1, marketIdLength);
-    loadDisputingDetails([...newMarketIdArray]);
+    loadDisputingDetails([...newMarketIdArray], () => {
+      const filtered = markets.filter(
+        m => newMarketIdArray.indexOf(m.id) !== -1
+      );
+      if (isUpcoming) {
+        this.setState({
+          filteredUpcomingMarkets: filtered
+        });
+      } else {
+        this.setState({
+          filteredNonForkingMarkets: filtered
+        });
+      }
+    });
   }
 
   filterMarkets(markets, lowerBound, boundedLength, showPagination) {
@@ -139,7 +168,6 @@ export default class DisputingMarkets extends Component {
       location,
       markets,
       outcomes,
-      upcomingMarkets,
       upcomingMarketsCount,
       forkingMarketId,
       paginationCount,
@@ -150,29 +178,13 @@ export default class DisputingMarkets extends Component {
       nullUpcomingMessage,
       addNullPadding
     } = this.props;
-    const {
-      lowerBound,
-      boundedLength,
-      lowerBoundUpcoming,
-      boundedLengthUpcoming
-    } = this.state;
+    const { filteredNonForkingMarkets, filteredUpcomingMarkets } = this.state;
 
     let forkingMarket = null;
-    let nonForkingMarkets = this.filterMarkets(
-      markets,
-      lowerBound,
-      boundedLength,
-      showPagination
-    );
-    const filteredUpcomingMarkets = this.filterMarkets(
-      upcomingMarkets,
-      lowerBoundUpcoming,
-      boundedLengthUpcoming,
-      showUpcomingPagination
-    );
+    let nonForkingMarkets = filteredNonForkingMarkets;
     if (isForking) {
       forkingMarket = markets.find(market => market.id === forkingMarketId);
-      nonForkingMarkets = nonForkingMarkets.filter(
+      nonForkingMarkets = filteredNonForkingMarkets.filter(
         market => market.id !== forkingMarketId
       );
     }

--- a/src/modules/reporting/components/common/disputing-markets.jsx
+++ b/src/modules/reporting/components/common/disputing-markets.jsx
@@ -73,7 +73,6 @@ export default class DisputingMarkets extends Component {
         this.props.disputableMarketIds,
         nextState.lowerBound,
         nextState.boundedLength,
-        nextProps.markets,
         false
       );
     }
@@ -85,28 +84,29 @@ export default class DisputingMarkets extends Component {
         this.props.upcomingDisputableMarketIds,
         nextState.lowerBoundUpcoming,
         nextState.boundedLengthUpcoming,
-        nextProps.upcomingMarkets,
         true
       );
     }
-    if (this.props.disputableMarketIds !== nextProps.disputableMarketIds) {
+    if (
+      this.props.disputableMarketIds !== nextProps.disputableMarketIds ||
+      this.props.markets.length !== nextProps.markets.length
+    ) {
       this.loadDisputingMarkets(
         nextProps.disputableMarketIds,
         nextState.lowerBound,
         nextState.boundedLength,
-        nextProps.markets,
         false
       );
     }
     if (
       this.props.upcomingDisputableMarketIds !==
-      nextProps.upcomingDisputableMarketIds
+        nextProps.upcomingDisputableMarketIds ||
+      this.props.upcomingMarkets.length !== nextProps.upcomingMarkets.length
     ) {
       this.loadDisputingMarkets(
         nextProps.upcomingDisputableMarketIds,
         nextState.lowerBoundUpcoming,
         nextState.boundedLengthUpcoming,
-        nextProps.upcomingMarkets,
         true
       );
     }
@@ -120,18 +120,14 @@ export default class DisputingMarkets extends Component {
     this.setState({ lowerBoundUpcoming, boundedLengthUpcoming });
   }
 
-  loadDisputingMarkets(
-    marketIds,
-    lowerBound,
-    boundedLength,
-    markets,
-    isUpcoming
-  ) {
+  loadDisputingMarkets(marketIds, lowerBound, boundedLength, isUpcoming) {
     const { loadDisputingDetails } = this.props;
     const marketIdLength = boundedLength + (lowerBound - 1);
     const newMarketIdArray = marketIds.slice(lowerBound - 1, marketIdLength);
     loadDisputingDetails([...newMarketIdArray], () => {
-      const filtered = markets.filter(
+      const { upcomingMarkets, markets } = this.props;
+      const marketCollection = isUpcoming ? upcomingMarkets : markets;
+      const filtered = marketCollection.filter(
         m => newMarketIdArray.indexOf(m.id) !== -1
       );
       if (isUpcoming) {

--- a/src/modules/reporting/containers/reporting-report-markets.js
+++ b/src/modules/reporting/containers/reporting-report-markets.js
@@ -6,8 +6,9 @@ import { selectMarketsToReport } from "modules/reports/selectors/select-markets-
 import { selectMarkets } from "src/modules/markets/selectors/markets-all";
 
 const mapStateToProps = state => {
+  const drAddress = state.loginAccount.address;
   const marketsData = selectMarkets(state);
-  const markets = selectMarketsToReport(marketsData);
+  const markets = selectMarketsToReport(marketsData, drAddress);
 
   return {
     isLogged: state.authStatus.isLogged,

--- a/src/modules/reports/actions/load-disputing-details.js
+++ b/src/modules/reports/actions/load-disputing-details.js
@@ -8,8 +8,13 @@ export const loadDisputingDetails = (
   marketIds,
   callback = logError
 ) => dispatch => {
-  dispatch(loadMarketsInfoIfNotLoaded(marketIds));
-  dispatch(loadMarketsDisputeInfo(marketIds), () => {
-    callback(null);
-  });
+  dispatch(
+    loadMarketsInfoIfNotLoaded(marketIds, () => {
+      dispatch(
+        loadMarketsDisputeInfo(marketIds, () => {
+          callback(null);
+        })
+      );
+    })
+  );
 };

--- a/src/modules/reports/selectors/select-markets-to-report.js
+++ b/src/modules/reports/selectors/select-markets-to-report.js
@@ -10,12 +10,14 @@ function filterForkedMarket(market) {
   );
 }
 
-export const selectMarketsToReport = marketsData => {
+export const selectMarketsToReport = (marketsData, loginAddress) => {
   const markets = {};
   markets.designated = marketsData
     .filter(
       market =>
-        market.reportingState === constants.REPORTING_STATE.DESIGNATED_REPORTING
+        market.reportingState ===
+          constants.REPORTING_STATE.DESIGNATED_REPORTING &&
+        market.designatedReporter === loginAddress
     )
     .sort((a, b) => (a.endTime || {}).timestamp - (b.endTime || {}).timestamp);
   markets.open = marketsData


### PR DESCRIPTION
Needed to get markets if not already loaded then get dispute info before filtering them for pagination.

also needed to filter designated reporting markets based on logged in user. one line item in a different bug. added here b/c it was easy to fix.

fixes https://github.com/AugurProject/augur/issues/846

