### PR TITLE
save if hasOpenOrders state after user interaction

### DIFF
--- a/src/modules/filter-sort/components/filter-dropdowns/filter-dropdowns.jsx
+++ b/src/modules/filter-sort/components/filter-dropdowns/filter-dropdowns.jsx
@@ -67,6 +67,7 @@ export default class FilterSearch extends Component {
     updateFilterOption: PropTypes.func.isRequired,
     updateSortOption: PropTypes.func.isRequired,
     updateMaxFee: PropTypes.func.isRequired,
+    updateHasOpenOrders: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired
   };
@@ -129,12 +130,21 @@ export default class FilterSearch extends Component {
   }
 
   changeHasOrders(event) {
-    const { filter, sort, maxFee, updateFilter, hasOrders } = this.props;
+    const {
+      filter,
+      sort,
+      maxFee,
+      updateFilter,
+      hasOrders,
+      updateHasOpenOrders
+    } = this.props;
+    const hasOpenOrders = !hasOrders;
+    updateHasOpenOrders(hasOpenOrders);
     updateFilter({
       filter,
       sort,
       maxFee,
-      hasOrders: !hasOrders
+      hasOrders: hasOpenOrders
     });
   }
 

--- a/src/modules/filter-sort/containers/filter-dropdowns.js
+++ b/src/modules/filter-sort/containers/filter-dropdowns.js
@@ -6,7 +6,8 @@ import {
   updateFilterSortOptions,
   MARKET_FILTER,
   MARKET_SORT,
-  MARKET_MAX_FEES
+  MARKET_MAX_FEES,
+  HAS_OPEN_ORDERS
 } from "modules/filter-sort/actions/update-filter-sort-options";
 
 const mapStateToProps = state => ({
@@ -21,7 +22,9 @@ const mapDispatchToProps = dispatch => ({
   updateSortOption: sortOption =>
     dispatch(updateFilterSortOptions(MARKET_SORT, sortOption)),
   updateMaxFee: maxFee =>
-    dispatch(updateFilterSortOptions(MARKET_MAX_FEES, maxFee))
+    dispatch(updateFilterSortOptions(MARKET_MAX_FEES, maxFee)),
+  updateHasOpenOrders: hasOpenOrders =>
+    dispatch(updateFilterSortOptions(HAS_OPEN_ORDERS, hasOpenOrders))
 });
 
 const FilterDropdownsContainer = withRouter(


### PR DESCRIPTION
fixes https://github.com/AugurProject/augur/issues/850


keep track of "has open orders" when user checks/unchecks the checkbox.