### PR TITLE
Profile UI Adjustments

### DIFF
--- a/src/modules/account/components/account-deposit/account-deposit.jsx
+++ b/src/modules/account/components/account-deposit/account-deposit.jsx
@@ -96,43 +96,11 @@ export default class AccountDeposit extends Component {
             <p>1. Click on your address on the right to copy it</p>
             <p>
               2. Go to Coinbase or Wyre (below) and buy Ether/ETH, and paste in
-              your address to send it. Note if you want immediate access use a
-              debit card, otherwise you&apos;ll have to wait a few days.
+              your address to send it. <br/><span className={Styles.AccountDeposit__note}>*Note if you want immediate access use a
+              debit card, otherwise you&apos;ll have to wait a few days.</span>
             </p>
-            <p>3. Come back here after and resume whatever you were doing!</p>
-            <div className={Styles.AccountDeposit__0xInstantButton}>
-              <button onClick={() => window.open("http://www.sendwyre.com/")}>
-                Buy ETH (for trading) using Wyre
-              </button>
-            </div>
-            <div className={Styles.AccountDeposit__0xInstantButton}>
-              <button
-                onClick={() => window.open("https://www.coinbase.com/buy/ETH")}
-              >
-                Buy ETH (for trading) using Coinbase
-              </button>
-            </div>
-            <br />
-            {show0xInstant && (
-              <div className={Styles.AccountDeposit__0xInstantButton}>
-                <button onClick={openZeroExInstant}>
-                  Buy REP (for reporting) using 0x instant
-                </button>
-              </div>
-            )}
-            {!show0xInstant && (
-              <div className={Styles.AccountDeposit__0xInstantButton}>
-                Deposits via 0x Instant are only available on the Ethereum main
-                network and Kovan test network.
-              </div>
-            )}
-            {showAirSwap && (
-              <div className={Styles.AccountDeposit__0xInstantButton}>
-                <button onClick={airSwapOnClick}>
-                  Buy REP (for reporting) using AirSwap
-                </button>
-              </div>
-            )}
+            <p>3. Check back here to see your updated balance.</p>
+
           </div>
           <div className={Styles.AccountDeposit__address}>
             <h3 className={Styles.AccountDeposit__addressLabel}>
@@ -158,10 +126,46 @@ export default class AccountDeposit extends Component {
                   )}
                 </span>
               </button>
+              <br/>
+            <QRCode value={address} style={styleQR} />
             </TextFit>
           </div>
           <div>
-            <QRCode value={address} style={styleQR} />
+          <h3 className={Styles.AccountDeposit__addressLabel}>ETH is used for Trading</h3>
+          <div className={Styles.AccountDeposit__0xInstantButton}>
+            <button onClick={() => window.open("http://www.sendwyre.com/")}>
+              Buy ETH using Wyre
+            </button>
+          </div>
+          <div className={Styles.AccountDeposit__0xInstantButton}>
+            <button
+              onClick={() => window.open("https://www.coinbase.com/buy/ETH")}
+            >
+              Buy ETH on Coinbase
+            </button>
+          </div>
+          <br />
+              <h3 className={Styles.AccountDeposit__addressLabel}>REP is used for Reporting</h3>
+          {show0xInstant && (
+            <div className={Styles.AccountDeposit__0xInstantButton}>
+              <button onClick={openZeroExInstant}>
+                Buy REP using 0x instant
+              </button>
+            </div>
+          )}
+          {!show0xInstant && (
+            <div className={Styles.AccountDeposit__0xInstantButton}>
+              Deposits via 0x Instant are only available on the Ethereum main
+              network and Kovan test network.
+            </div>
+          )}
+          {showAirSwap && (
+            <div className={Styles.AccountDeposit__0xInstantButton}>
+              <button onClick={airSwapOnClick}>
+                Buy REP using AirSwap
+              </button>
+            </div>
+          )}
           </div>
         </div>
       </section>

--- a/src/modules/account/components/account-deposit/account-deposit.styles.less
+++ b/src/modules/account/components/account-deposit/account-deposit.styles.less
@@ -4,7 +4,10 @@
   background: white;
   padding: 5.5rem 4.625rem 7rem;
 }
-
+.AccountDeposit__note {
+      font-style: italic;
+      font-size: 0.9rem;
+}
 .AccountDeposit__heading {
   margin-bottom: 2.5rem;
 
@@ -34,12 +37,12 @@
     }
 
     &:nth-child(2) {
-      width: 47%;
+      width: 42%;
     }
 
     &:last-child {
       padding-right: 0;
-      width: 20%;
+      width: 25%;
     }
 
     &:not(:first-child) {


### PR DESCRIPTION
Made some simple UI changes to the profile page, attached screenshot below.

Reason for the adjustments:
->Trade buttons went outside of view range on profile page
->QR Code had a dedicated section, which could be better suited under the public address 

Changes Made:
->Moved trade buttons to far right column
->Moved QR code to show under public address (makes more sense, as these are the same)
->Added a italicized span for step #2 where it says note

![adjustment](https://user-images.githubusercontent.com/20643750/51442941-5f49ba80-1cb0-11e9-9e1d-4b1b7a4b8290.PNG)
