### PR TITLE
Load "In Reporting" markets with just one getMarkets() API call

### DIFF
--- a/src/modules/markets/actions/load-markets.js
+++ b/src/modules/markets/actions/load-markets.js
@@ -130,10 +130,12 @@ export const loadMarketsByFilter = (filterOptions, cb = () => {}) => (
   switch (filterOptions.filter) {
     case MARKET_REPORTING: {
       // reporting markets only:
-      filter.push(REPORTING_STATE.DESIGNATED_REPORTING);
-      filter.push(REPORTING_STATE.OPEN_REPORTING);
-      filter.push(REPORTING_STATE.CROWDSOURCING_DISPUTE);
-      filter.push(REPORTING_STATE.AWAITING_NEXT_WINDOW);
+      filter.push([
+        REPORTING_STATE.DESIGNATED_REPORTING,
+        REPORTING_STATE.OPEN_REPORTING,
+        REPORTING_STATE.CROWDSOURCING_DISPUTE,
+        REPORTING_STATE.AWAITING_NEXT_WINDOW
+      ]);
       filter.forEach(filterType => {
         parallelParams[filterType] = next =>
           augur.markets.getMarkets(
@@ -145,8 +147,10 @@ export const loadMarketsByFilter = (filterOptions, cb = () => {}) => (
     }
     case MARKET_CLOSED: {
       // resolved markets only:
-      filter.push(REPORTING_STATE.AWAITING_FINALIZATION);
-      filter.push(REPORTING_STATE.FINALIZED);
+      filter.push([
+        REPORTING_STATE.AWAITING_FINALIZATION,
+        REPORTING_STATE.FINALIZED
+      ]);
       filter.forEach(filterType => {
         parallelParams[filterType] = next =>
           augur.markets.getMarkets(


### PR DESCRIPTION
Fixes AugurProject/augur#812

Depends on https://github.com/AugurProject/augur-node/pull/803 which is currently merged and allows `getMarkets()` to pass an array of `ReportingState`

Future work: a similar fix might be applied to `src/modules/reports/actions/load-markets-to-report-on.js`