### PR TITLE
fix-dispute-choices

### DIFF
--- a/src/modules/reports/selectors/select-dispute-outcomes.js
+++ b/src/modules/reports/selectors/select-dispute-outcomes.js
@@ -71,7 +71,7 @@ export default function(
   const sortedOutcomes = filteredOutcomes.sort((a, b) => sortOutcomes(a, b));
 
   sortedOutcomes.map((outcome, index) => {
-    if (index < TopOutcomeCount - 1 || outcome.id === invalidMarketId) {
+    if (index <= TopOutcomeCount - 1 || outcome.id === invalidMarketId) {
       outcome.display = true;
     }
     if (outcome.id === MALFORMED_OUTCOME) {

--- a/src/modules/reports/selectors/select-dispute-outcomes.test.js
+++ b/src/modules/reports/selectors/select-dispute-outcomes.test.js
@@ -204,6 +204,7 @@ describe(`modules/reports/selectors/select-dispute-outcomes.js`, () => {
         tentativeWinning: false,
         stakeCurrent: "30",
         stakeRemaining: "70",
+        display: true,
         id: "30",
         name: "30"
       },


### PR DESCRIPTION
fixed an issue that would cause the 8th outcome to not display on a dispute form if invalid is the tentative winning outcome of an 8 category categorical market.

To test locally, fire up a pop node but not with normal time.

make an 8 outcome categorical market, push to reporting using flash, report `INVALID` then push 1 week to dispute rounds, go to dispute form and notice that outcome 1-8 are all being displayed properly now.