### PR TITLE
Report button bug

### DIFF
--- a/src/modules/market/components/market-header/market-header-reporting.jsx
+++ b/src/modules/market/components/market-header/market-header-reporting.jsx
@@ -8,7 +8,11 @@ import Styles from "modules/market/components/market-header/market-header-report
 import { constants } from "services/constants";
 import MarketLink from "modules/market/components/market-link/market-link";
 import MarketHeaderStyles from "modules/market/components/market-header/market-header.styles";
-import { CATEGORICAL, TYPE_DISPUTE } from "modules/common-elements/constants";
+import {
+  CATEGORICAL,
+  TYPE_DISPUTE,
+  TYPE_REPORT
+} from "modules/common-elements/constants";
 import { createBigNumber } from "utils/create-big-number";
 
 export default class MarketHeaderReporting extends Component {
@@ -20,7 +24,8 @@ export default class MarketHeaderReporting extends Component {
     claimTradingProceeds: PropTypes.func.isRequired,
     getWinningBalances: PropTypes.func.isRequired,
     tentativeWinner: PropTypes.object,
-    isLogged: PropTypes.bool
+    isLogged: PropTypes.bool,
+    location: PropTypes.object.isRequired
   };
 
   static defaultProps = {
@@ -60,7 +65,8 @@ export default class MarketHeaderReporting extends Component {
       claimTradingProceeds,
       tentativeWinner,
       isLogged,
-      currentTimestamp
+      currentTimestamp,
+      location
     } = this.props;
     const {
       reportingState,
@@ -252,6 +258,7 @@ export default class MarketHeaderReporting extends Component {
                 id={id}
                 location={location}
                 disabled={!isLogged}
+                linkType={TYPE_REPORT}
               >
                 Report
               </MarketLink>

--- a/src/modules/market/components/market-orders-positions-table/open-orders-table.jsx
+++ b/src/modules/market/components/market-orders-positions-table/open-orders-table.jsx
@@ -30,8 +30,8 @@ const OpenOrdersTable = ({
           <span>Quantity</span>
         </li>
         <li>Price</li>
-        <li>Escrowed ETH</li>
-        <li>Escrowed Shares</li>
+        <li>Total Cost (ETH)</li>
+        <li>Total Cost (Shares)</li>
         {!isMobile && (
           <li>
             <span>Action</span>


### PR DESCRIPTION
- On Open Orders, change 'Escrowed Eth' and 'Escrowed Shares' labels to 'Total Cost (ETH)' and 'Total Cost (Shares)' 


- On a market that can be reported on, if I go to the trading pg and hit report button nothing happens 