### PR TITLE
Add movement label

### DIFF
--- a/src/assets/styles/_colors_redesign.less
+++ b/src/assets/styles/_colors_redesign.less
@@ -31,3 +31,7 @@
 @color-primary-button-text: @color-primary-text; // #140E1F
 @color-secondary-button-text: @color-secondary-text; // #FFFFFF
 @color-secondary-button-text-disabled: @color-secondary-text-disabled;
+
+@color-movement-positive: @color-buy-order-button-border; // #00F1C4
+@color-movement-negative: @color-sell-order-button-border;  // #FF7D5E
+@color-movement-neutral: rgb(153, 153, 153, 1); // #999999

--- a/src/modules/common-elements/constants.ts
+++ b/src/modules/common-elements/constants.ts
@@ -501,6 +501,9 @@ export const COMPLETE_SETS_SOLD = "CompleteSetsSold";
 export const TRANSFER_FUNDS = "transfer_funds";
 export const SENT_CASH = "sent_cash";
 export const SENT_ETHER = "sent_ether";
+export const SMALL = 'small';
+export const NORMAL = 'normal';
+export const LARGE = 'large';
 
 // Trade/order labels
 export const BID = "bid";

--- a/src/modules/common-elements/movement-icon.tsx
+++ b/src/modules/common-elements/movement-icon.tsx
@@ -16,7 +16,6 @@ export interface MovementIconProps {
 }
 
 const MovementIcon = (props: MovementIconProps) => {
-  // Set styles
   const getIconSizeStyles: Function = (size: sizeTypes): string => {
     return classNames(Styles.MovementLabel_Icon, {
       [Styles.MovementLabel_Icon_small]: size == sizeTypes.SMALL,
@@ -32,14 +31,10 @@ const MovementIcon = (props: MovementIconProps) => {
     });
   };
 
-  const styles = `${getIconSizeStyles(props.size)} ${getIconColorStyles(
-    props.value
-  )}`;
+  const iconSize = getIconSizeStyles(props.size);
+  const iconColor = getIconColorStyles(props.value);
 
-  // Render
-  const MovementIcon = <div className={styles}>{marketIcon}</div>;
-
-  return MovementIcon;
+  return <div className={`${iconSize} ${iconColor}`}>{marketIcon}</div>;
 };
 
 export default MovementIcon;

--- a/src/modules/common-elements/movement-icon.tsx
+++ b/src/modules/common-elements/movement-icon.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import classNames from "classnames";
+import * as constants from "./constants";
+import { marketIcon } from "modules/common/components/icons";
+import Styles from "./movement-label.styles";
+
+export enum sizeTypes {
+  SMALL = constants.SMALL,
+  NORMAL = constants.NORMAL,
+  LARGE = constants.LARGE
+}
+
+export interface MovementIconProps {
+  value: number;
+  size: sizeTypes;
+}
+
+const MovementIcon = (props: MovementIconProps) => {
+  // Set styles
+  const getIconSizeStyles: Function = (size: sizeTypes): string => {
+    return classNames(Styles.MovementLabel_Icon, {
+      [Styles.MovementLabel_Icon_small]: size == sizeTypes.SMALL,
+      [Styles.MovementLabel_Icon_normal]: size == sizeTypes.NORMAL,
+      [Styles.MovementLabel_Icon_large]: size == sizeTypes.LARGE
+    });
+  };
+
+  const getIconColorStyles: Function = (value: number): string => {
+    return classNames({
+      [Styles.MovementLabel_Icon_positive]: value > 0,
+      [Styles.MovementLabel_Icon_negative]: value < 0
+    });
+  };
+
+  const styles = `${getIconSizeStyles(props.size)} ${getIconColorStyles(
+    props.value
+  )}`;
+
+  // Render
+  const MovementIcon = <div className={styles}>{marketIcon}</div>;
+
+  return MovementIcon;
+};
+
+export default MovementIcon;

--- a/src/modules/common-elements/movement-label.styles.less
+++ b/src/modules/common-elements/movement-label.styles.less
@@ -1,0 +1,72 @@
+@import (reference) '~assets/styles/shared';
+
+.MovementLabel {
+  align-items: center;
+  color: @color-movement-neutral;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.MovementLabel_Text {
+  .number-default;
+
+  &_small {
+    .number-smallest;
+  }
+
+  &_normal {
+    .number-small;
+  }
+
+  &_large {
+    .number-medium;
+  }
+
+  &_positive {
+    color: @color-movement-positive;
+  }
+
+  &_negative {
+    color: @color-movement-negative;
+  }
+}
+
+.MovementLabel_Icon {
+  margin: 0 0.5rem 0 0;
+
+  &_small {
+    transform: scale(0.8);
+  }
+
+  &_normal {
+    transform: scale(0.9);
+  }
+
+  &_large {
+    transform: scale(1);
+  }
+
+  &_positive {
+    > svg > path:nth-child(1) {
+      fill: @color-movement-positive;
+    }
+
+    > svg > path:nth-child(2) {
+      stroke: @color-movement-positive;
+    }
+  }
+
+  &_negative {
+    > svg {
+      transform: rotateX(180deg);
+    }
+
+    > svg > path:nth-child(1) {
+      fill: @color-movement-negative;
+    }
+
+    > svg > path:nth-child(2) {
+      stroke: @color-movement-negative;
+    }
+  }
+}

--- a/src/modules/common-elements/movement-label.tsx
+++ b/src/modules/common-elements/movement-label.tsx
@@ -13,23 +13,30 @@ export enum sizeTypes {
 export interface MovementLabelProps {
   value: number;
   size: sizeTypes;
+  styles?: object;
   showColors?: boolean;
   showIcon?: boolean;
   showBrackets?: boolean;
-  showPercentSign?: boolean;
-  showPositiveSign?: boolean;
+  showPercent?: boolean;
+  showPlusMinus?: boolean;
 }
 
 const MovementLabel = (props: MovementLabelProps) => {
-  // Set Defaults
-  const showColors = props.showColors || false;
-  const showPercentSign = props.showPercentSign || false;
-  const showBrackets = props.showBrackets || false;
-  const showPositiveSign = props.showPositiveSign || false;
-  const showIcon = props.showIcon || false;
+  const showColors = props.showColors || false;          // Red/Green
+  const showPercent = props.showPercent || false;        // 0.00%
+  const showBrackets = props.showBrackets || false;      // (0.00)
+  const showPlusMinus = props.showPlusMinus || false;    // +4.32 / -0.32
+  const showIcon = props.showIcon || false;              // 📈 3.2 / 📉 2.1
 
   return (
-    <div className={Styles.MovementLabel}>
+    <div
+      className={Styles.MovementLabel}
+      style={
+        showIcon
+          ? { ...props.styles, justifyContent: "space-between" }
+          : { ...props.styles, justifyContent: "flex-end" }
+      }
+    >
       {showIcon &&
         props.value !== 0 && (
           <MovementIcon value={props.value} size={props.size} />
@@ -39,9 +46,9 @@ const MovementLabel = (props: MovementLabelProps) => {
           value={props.value}
           size={props.size}
           showColors={showColors}
-          showPercentSign={showPercentSign}
+          showPercent={showPercent}
           showBrackets={showBrackets}
-          showPositiveSign={showPositiveSign}
+          showPlusMinus={showPlusMinus}
         />
       }
     </div>

--- a/src/modules/common-elements/movement-label.tsx
+++ b/src/modules/common-elements/movement-label.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import * as constants from "./constants";
+import MovementText from "modules/common-elements/movement-text";
+import MovementIcon from "modules/common-elements/movement-icon";
+import Styles from "./movement-label.styles";
+
+export enum sizeTypes {
+  SMALL = constants.SMALL,
+  NORMAL = constants.NORMAL,
+  LARGE = constants.LARGE
+}
+
+export interface MovementLabelProps {
+  value: number;
+  size: sizeTypes;
+  showColors?: boolean;
+  showIcon?: boolean;
+  showBrackets?: boolean;
+  showPercentSign?: boolean;
+  showPositiveSign?: boolean;
+}
+
+const MovementLabel = (props: MovementLabelProps) => {
+  // Set Defaults
+  const showColors = props.showColors || false;
+  const showPercentSign = props.showPercentSign || false;
+  const showBrackets = props.showBrackets || false;
+  const showPositiveSign = props.showPositiveSign || false;
+  const showIcon = props.showIcon || false;
+
+  return (
+    <div className={Styles.MovementLabel}>
+      {showIcon &&
+        props.value !== 0 && (
+          <MovementIcon value={props.value} size={props.size} />
+        )}
+      {
+        <MovementText
+          value={props.value}
+          size={props.size}
+          showColors={showColors}
+          showPercentSign={showPercentSign}
+          showBrackets={showBrackets}
+          showPositiveSign={showPositiveSign}
+        />
+      }
+    </div>
+  );
+};
+
+export default MovementLabel;

--- a/src/modules/common-elements/movement-text.tsx
+++ b/src/modules/common-elements/movement-text.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import classNames from "classnames";
+import * as constants from "./constants";
+import Styles from "./movement-label.styles";
+
+export enum sizeTypes {
+  SMALL = constants.SMALL,
+  NORMAL = constants.NORMAL,
+  LARGE = constants.LARGE
+}
+
+export interface MovementTextProps {
+  value: number;
+  size: sizeTypes;
+  showColors: boolean;
+  showBrackets: boolean;
+  showPercentSign: boolean;
+  showPositiveSign: boolean;
+}
+
+const MovementText = (props: MovementTextProps) => {
+  const getTextSizeStyle: Function = (size: sizeTypes): string => {
+    return classNames(Styles.MovementLabel_Text, {
+      [Styles.MovementLabel_Text_small]: size == sizeTypes.SMALL,
+      [Styles.MovementLabel_Text_normal]: size == sizeTypes.NORMAL,
+      [Styles.MovementLabel_Text_large]: size == sizeTypes.LARGE
+    });
+  };
+  const getTextColorStyles: Function = (value: number): string => {
+    return classNames({
+      [Styles.MovementLabel_Text_positive]: value > 0,
+      [Styles.MovementLabel_Text_negative]: value < 0,
+      [Styles.MovementLabel_Text_neutral]: value === 0
+    });
+  };
+
+  // Set styles
+  const textColorStyle = getTextColorStyles(props.value);
+  const textSizeStyle = getTextSizeStyle(props.size);
+
+  // Transform label
+  const addPositiveSign: Function = (value: number): string | void => {
+    if (props.value > 0 && props.showPositiveSign) {
+      return "+".concat(String(value));
+    }
+    return String(value);
+  };
+
+  const addBrackets: Function = (
+    showBrackets: boolean,
+    label: string
+  ): string | void => {
+    if (showBrackets) {
+      return `(${label})`;
+    }
+    return label;
+  };
+
+  const addPercentSign: Function = (
+    showPercentSign: boolean,
+    label: string
+  ): string | void => {
+    if (showPercentSign) {
+      return `${label}%`;
+    }
+    return label;
+  };
+
+  let formattedString = props.value;
+  formattedString = addPositiveSign(formattedString);
+  formattedString = addPercentSign(props.showPercentSign, formattedString);
+  formattedString = addBrackets(props.showBrackets, formattedString);
+
+  // Render
+  const MovementText = (
+    <div
+      className={`${props.showColors ? textColorStyle : ""} ${textSizeStyle}`}
+    >
+      {formattedString}
+    </div>
+  );
+
+  return MovementText;
+};
+
+export default MovementText;

--- a/src/modules/common-elements/movement-text.tsx
+++ b/src/modules/common-elements/movement-text.tsx
@@ -14,8 +14,8 @@ export interface MovementTextProps {
   size: sizeTypes;
   showColors: boolean;
   showBrackets: boolean;
-  showPercentSign: boolean;
-  showPositiveSign: boolean;
+  showPercent: boolean;
+  showPlusMinus: boolean;
 }
 
 const MovementText = (props: MovementTextProps) => {
@@ -34,53 +34,53 @@ const MovementText = (props: MovementTextProps) => {
     });
   };
 
-  // Set styles
   const textColorStyle = getTextColorStyles(props.value);
   const textSizeStyle = getTextSizeStyle(props.size);
 
   // Transform label
-  const addPositiveSign: Function = (value: number): string | void => {
-    if (props.value > 0 && props.showPositiveSign) {
-      return "+".concat(String(value));
-    }
-    return String(value);
-  };
-
-  const addBrackets: Function = (
-    showBrackets: boolean,
-    label: string
-  ): string | void => {
-    if (showBrackets) {
-      return `(${label})`;
+  const removeMinus: Function = (label: number): number => {
+    if (props.value < 0 && !props.showPlusMinus) {
+      return Math.abs(props.value);
     }
     return label;
   };
 
-  const addPercentSign: Function = (
-    showPercentSign: boolean,
-    label: string
-  ): string | void => {
-    if (showPercentSign) {
+  const toString: Function = (label: number): string => {
+    return String(label);
+  };
+
+  const addPlus: Function = (label: string): string => {
+    if (props.value > 0 && props.showPlusMinus) {
+      return "+".concat(label);
+    }
+    return label;
+  };
+
+  const addPercent: Function = (label: string): string => {
+    if (props.showPercent) {
       return `${label}%`;
     }
     return label;
   };
 
-  let formattedString = props.value;
-  formattedString = addPositiveSign(formattedString);
-  formattedString = addPercentSign(props.showPercentSign, formattedString);
-  formattedString = addBrackets(props.showBrackets, formattedString);
+  const addBrackets: Function = (label: string): string => {
+    if (props.showBrackets) {
+      return `(${label})`;
+    }
+    return label;
+  };
 
-  // Render
-  const MovementText = (
+  const formattedString = addBrackets(
+    addPercent(addPlus(toString(removeMinus(props.value))))
+  );
+
+  return (
     <div
       className={`${props.showColors ? textColorStyle : ""} ${textSizeStyle}`}
     >
       {formattedString}
     </div>
   );
-
-  return MovementText;
 };
 
 export default MovementText;

--- a/src/modules/common/components/icons.jsx
+++ b/src/modules/common/components/icons.jsx
@@ -1993,3 +1993,24 @@ export const infoIcon = (
     />
   </svg>
 );
+
+export const marketIcon = (
+  <svg
+    width="14"
+    height="9"
+    viewBox="0 0 14 9"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M13.25 0.5H13.75C13.75 0.223858 13.5261 0 13.25 0V0.5ZM12.75 4.41304C12.75 4.68919 12.9739 4.91304 13.25 4.91304C13.5261 4.91304 13.75 4.68919 13.75 4.41304H12.75ZM9.5 0C9.22386 0 9 0.223858 9 0.5C9 0.776142 9.22386 1 9.5 1V0ZM12.75 0.5V4.41304H13.75V0.5H12.75ZM9.5 1H13.25V0H9.5V1Z"
+      fill="#00F1C4"
+    />
+    <path
+      d="M12.5 1.29004L7.1967 6.82392L4.56723 4.08013L1.20142 7.59229"
+      stroke="#00F1C4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);


### PR DESCRIPTION
### Create  Price Movement Label

- Added a common element to use for price movement display. There are quite a few places in the redesign that will use this for display. 
<img src="https://user-images.githubusercontent.com/1683736/52789842-06f9a480-3033-11e9-8030-054432d6475b.png" height="55px" />


- I Will add this to (and fix other redesign style issues on) the TopBar component, but on a seperate PR.
