### PR TITLE
Add Account Summary / Notification layout

### DIFF
--- a/src/modules/account/components/account-header/account-header.jsx
+++ b/src/modules/account/components/account-header/account-header.jsx
@@ -1,37 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
-import TextFit from "react-textfit";
 
 import Styles from "modules/account/components/account-header/account-header.styles";
 
-const AccountHeader = ({ stats }) => {
-  // assign defaults incase we have nulls for value
-  const ethValue = stats[0].totalRealEth.value.formatted;
-  const repValue = stats[0].totalRep.value.formatted;
-
-  return (
-    <TextFit mode="single" min={16} max={90}>
-      <div className={Styles.AccountHeader}>
-        <h4>Available Balance</h4>
-        <div className={Styles.AccountHeader__Currency}>
-          <span className="eth_value"> {ethValue} </span>
-          <span className={Styles["AccountHeader__Currency-label"]}>
-            {stats[0].totalRealEth.label}
-          </span>
-        </div>
-        <div className={Styles.AccountHeader__Currency}>
-          <span className="rep_value"> {repValue} </span>
-          <span className={Styles["AccountHeader__Currency-label"]}>
-            {stats[0].totalRep.label}
-          </span>
-        </div>
-      </div>
-    </TextFit>
-  );
-};
-
-AccountHeader.propTypes = {
-  stats: PropTypes.array.isRequired
-};
+const AccountHeader = () => (
+  <section className={Styles.AccountHeader}>
+    <div className={Styles.AccountHeader__header}>
+      <h1 className={Styles.AccountHeader__title}>Account Summary</h1>
+    </div>
+  </section>
+);
 
 export default AccountHeader;

--- a/src/modules/account/components/account-header/account-header.styles.less
+++ b/src/modules/account/components/account-header/account-header.styles.less
@@ -1,58 +1,20 @@
 @import (reference) '~assets/styles/shared';
 
 .AccountHeader {
-  color: white;
+  color: @color-secondary-text;
+  margin: 3rem 2.5rem 1.5rem;
+}
+
+.AccountHeader__header {
+  align-items: flex-end;
   display: flex;
-  flex-flow: row wrap;
-  margin: 10rem 4.625rem 1.75rem;
-
-  > h4 {
-    .text-24-bold;
-
-    color: @color-light-gray;
-    flex: 0 0 100%;
-  }
+  justify-content: space-between;
 }
 
-.AccountHeader__Currency {
-  font-weight: 200;
-  letter-spacing: 0.004em;
+.AccountHeader__title {
+  .text-30-bold;
 
-  &:not(:first-child) {
-    margin-left: 0.4em;
-  }
-
-  &:first-of-type {
-    margin-left: 0;
-  }
-}
-
-.AccountHeader__Currency-label {
-  font-size: 0.33em;
-  font-weight: 500;
-  letter-spacing: 0.001em;
-  text-transform: uppercase;
-}
-
-@media @breakpoint-mobile {
-  .AccountHeader {
-    display: block;
-    margin: 4rem 2.25rem 3.2rem;
-
-    > h4 {
-      .text-16;
-    }
-  }
-
-  .AccountHeader__Currency:not(:first-child) {
-    margin-left: 0;
-    margin-top: 0.2em;
-  }
-}
-
-@media @breakpoint-mobile-medium {
-  .AccountHeader {
-    margin-bottom: 2.2rem;
-    margin-top: 3rem;
-  }
+  color: @color-secondary-text;
+  margin-bottom: 0;
+  text-transform: capitalize;
 }

--- a/src/modules/account/components/account-view/account-view.jsx
+++ b/src/modules/account/components/account-view/account-view.jsx
@@ -7,9 +7,8 @@ import NotificationBox from "modules/account/components/notifications/notificati
 
 import Styles from "modules/account/components/account-view/account-view.styles";
 
-
 const AccountView = () => {
-  let notifications = []; // TODO;
+  const notifications = []; // TODO;
 
   return (
     <section className={Styles.AccountView}>

--- a/src/modules/account/components/account-view/account-view.jsx
+++ b/src/modules/account/components/account-view/account-view.jsx
@@ -1,55 +1,26 @@
 import React from "react";
-import { Switch } from "react-router-dom";
-
-import AuthenticatedRoute from "modules/routes/components/authenticated-route/authenticated-route";
 
 import AccountHeader from "modules/account/containers/account-header";
-import AccountDeposit from "modules/account/containers/account-deposit";
-import AccountWithdraw from "modules/account/containers/account-withdraw";
-import AccountRepFaucet from "modules/account/containers/account-rep-faucet";
-import AccountUniverses from "modules/account/containers/account-universes";
 import TermsAndConditions from "modules/app/containers/terms-and-conditions";
-
-import { augur } from "services/augurjs";
-
-import makePath from "modules/routes/helpers/make-path";
-
-import {
-  ACCOUNT_DEPOSIT,
-  ACCOUNT_WITHDRAW,
-  ACCOUNT_REP_FAUCET,
-  ACCOUNT_UNIVERSES
-} from "modules/routes/constants/views";
+import QuadBox from "modules/portfolio/components/common/quads/quad-box";
+import NotificationBox from "modules/account/components/notifications/notification-box";
 
 import Styles from "modules/account/components/account-view/account-view.styles";
 
-const AccountView = p => {
-  const showRepFaucet = parseInt(augur.rpc.getNetworkID(), 10) !== 1;
+
+const AccountView = () => {
+  let notifications = []; // TODO;
 
   return (
     <section className={Styles.AccountView}>
-      <div>
-        <AccountHeader />
-        <Switch>
-          <AuthenticatedRoute
-            path={makePath(ACCOUNT_DEPOSIT)}
-            component={AccountDeposit}
-          />
-          <AuthenticatedRoute
-            path={makePath(ACCOUNT_WITHDRAW)}
-            component={AccountWithdraw}
-          />
-          {showRepFaucet && (
-            <AuthenticatedRoute
-              path={makePath(ACCOUNT_REP_FAUCET)}
-              component={AccountRepFaucet}
-            />
-          )}
-          <AuthenticatedRoute
-            path={makePath(ACCOUNT_UNIVERSES)}
-            component={AccountUniverses}
-          />
-        </Switch>
+      <AccountHeader />
+      <div className={Styles.AccountView__container}>
+        <NotificationBox notifications={notifications} />
+        <QuadBox title="Your Overview" />
+        <QuadBox title="Watchlist" />
+        <QuadBox title="Open Markets" />
+        <QuadBox title="Augur Status" />
+        <QuadBox title="Transactions" />
       </div>
       <TermsAndConditions />
     </section>

--- a/src/modules/account/components/account-view/account-view.styles.less
+++ b/src/modules/account/components/account-view/account-view.styles.less
@@ -1,14 +1,25 @@
+@import (reference) '~assets/styles/shared';
+
 .AccountView {
   display: flex;
   flex-direction: column;
-  height: 100%;
+}
 
-  > div:first-child {
-    flex-grow: 1;
-    margin-bottom: 0.875rem;
+.AccountView__container {
+  display: grid;
+  grid-gap: 0.75rem;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(2, 55vh);
+  margin: 0 2.5rem 2.5rem;
+
+  > div {
+    max-height: 100%;
   }
+}
 
-  > div:last-child {
-    flex-grow: 0;
+@media @breakpoint-mobile {
+  .AccountView__container {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
   }
 }

--- a/src/modules/account/components/notifications/notification-box.styles.less
+++ b/src/modules/account/components/notifications/notification-box.styles.less
@@ -1,0 +1,32 @@
+@import (reference) '~assets/styles/shared';
+
+.NotificationBox {
+  background: @color-theme-primary;
+  border: 1px solid @color-secondary-border;
+  border-radius: 3px;
+  color: @color-secondary-text;
+  flex: 1;
+  max-height: 50%;
+  min-height: 50%;
+  padding-bottom: 1.5rem;
+}
+
+.NotificationBox__header {
+  .mono-10;
+
+  align-items: center;
+  display: flex;
+
+  > :first-child {
+    color: @color-highlight;
+    margin: 0 4px 0 0;
+  }
+}
+
+.NotificationBox__content {
+  background: @color-secondary-background;
+  border-bottom: 1px solid @color-secondary-background;
+  flex: 1;
+  height: calc(100% - 3.75rem);
+  overflow: scroll;
+}

--- a/src/modules/account/components/notifications/notification-box.tsx
+++ b/src/modules/account/components/notifications/notification-box.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+
+import BoxHeader from "modules/portfolio/components/common/headers/box-header";
+import { NotificationCard } from "modules/common-elements/notifications";
+import { PillLabel } from "modules/common-elements/labels";
+import * as constants from "modules/common-elements/constants";
+
+import Styles from "modules/account/components/notifications/notification-box.styles";
+
+export interface Notifications {
+  isImportant: boolean;
+  isNew: boolean;
+  title: string;
+  buttonLabel: string;
+  buttonAction: Function;
+  marketName?: string;
+  round?: number;
+  amount?: number;
+  countDown: Date;
+  Template: React.StatelessComponent<any>;
+}
+
+export interface NotificationBoxProps {
+  notifications: Array<Notifications>;
+}
+
+const NotificationBox = (props: NotificationBoxProps) => {
+  const { notifications } = props;
+  const notificationCount = notifications.length;
+  const newNotificationCount = notifications.filter((item: any) => item.isNew)
+    .length;
+
+  const rows = notifications.map((notification: Notifications, idx: number) => {
+    const {
+      Template,
+      marketName,
+      round,
+      amount,
+      countDown,
+      isImportant,
+      isNew,
+      title,
+      buttonLabel,
+      buttonAction
+    } = notification;
+
+    const templateProps = { marketName, amount, round, countDown };
+    const notificationCardProps = {
+      isImportant,
+      isNew,
+      title,
+      buttonLabel,
+      buttonAction
+    };
+    return (
+      <NotificationCard key={idx} {...notificationCardProps}>
+        <Template {...templateProps} />
+      </NotificationCard>
+    );
+  });
+
+  const labelContent = (
+    <div className={Styles.NotificationBox__header}>
+      <span>{`(${notificationCount} Notifications)`}</span>
+      {newNotificationCount > 0 && (
+        <PillLabel label={`${newNotificationCount} ${constants.NEW}`} />
+      )}
+    </div>
+  );
+
+  return (
+    <div className={Styles.NotificationBox}>
+      <BoxHeader title="Notifications" rightContent={labelContent} />
+      <div className={Styles.NotificationBox__content}>{rows}</div>
+    </div>
+  );
+};
+
+export default NotificationBox;

--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -176,8 +176,6 @@ export default class AppView extends Component {
         title: "Account",
         iconName: "nav-account-icon",
         icon: NavAccountIcon,
-        mobileClick: () =>
-          this.setState({ mobileMenuState: mobileMenuStates.FIRSTMENU_OPEN }),
         route: ACCOUNT_DEPOSIT,
         requireLogin: true
       },
@@ -291,6 +289,13 @@ export default class AppView extends Component {
       : this.state.currentInnerNavType;
     const newType = navTypes[nextBasePath];
 
+    // Don't show mainMenu/subMenu for Account Summary
+    if (newType === AccountInnerNav) {
+      return this.toggleMenuTween(SUB_MENU, false, () => {
+        return this.toggleMenuTween(MAIN_MENU, false);
+      });
+    }
+
     if ((newType === AccountInnerNav && !isLogged) || oldType === newType) {
       return;
     }
@@ -318,9 +323,6 @@ export default class AppView extends Component {
         case MY_MARKETS:
         case MY_POSITIONS:
         case FAVORITES:
-        case ACCOUNT_DEPOSIT:
-        case ACCOUNT_WITHDRAW:
-        case ACCOUNT_REP_FAUCET:
         case REPORTING_DISPUTE_MARKETS:
         case REPORTING_REPORT_MARKETS:
         case REPORTING_RESOLVED_MARKETS:

--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -291,9 +291,9 @@ export default class AppView extends Component {
 
     // Don't show mainMenu/subMenu for Account Summary
     if (newType === AccountInnerNav) {
-      return this.toggleMenuTween(SUB_MENU, false, () => {
-        return this.toggleMenuTween(MAIN_MENU, false);
-      });
+      return this.toggleMenuTween(SUB_MENU, false, () =>
+        this.toggleMenuTween(MAIN_MENU, false)
+      );
     }
 
     if ((newType === AccountInnerNav && !isLogged) || oldType === newType) {

--- a/src/modules/app/components/terms-and-conditions/terms-and-conditions.styles.less
+++ b/src/modules/app/components/terms-and-conditions/terms-and-conditions.styles.less
@@ -4,7 +4,7 @@
   color: @color-text-light;
   display: flex;
   flex: 0 0 auto;
-  font-size: @font-size-normal;
+  font-size: 0.75rem;
   justify-content: space-between;
   margin: 1em 0;
   text-align: center;
@@ -62,6 +62,7 @@
     }
 
     .TermsAndConditions__grouping {
+      align-content: space-around;
       display: flex;
       flex-flow: column wrap;
 
@@ -69,7 +70,7 @@
       span {
         align-self: flex-start;
         flex-basis: 100%;
-        font-size: @font-size-normal;
+        font-size: 0.75rem;
         padding: 0.5em 0;
       }
     }

--- a/src/modules/common-elements/constants.ts
+++ b/src/modules/common-elements/constants.ts
@@ -548,3 +548,6 @@ export const VOLUME_ETH_SHARES = [
     label: SHARES
   }
 ]
+
+// Account Summary - Notifications
+export const NEW = "New";

--- a/src/modules/common-elements/icons.tsx
+++ b/src/modules/common-elements/icons.tsx
@@ -50,7 +50,7 @@ export const TwoArrows =
   </svg>
 ;
 
-export const InfoIcon = 
+export const InfoIcon =
   <svg viewBox="0 0 18 18">
     <circle cx="9" cy="9" r="8"/>
     <path
@@ -68,3 +68,11 @@ export const SearchIcon = (
     </g>
   </svg>
 );
+
+export const ImmediateImportance =
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle opacity="0.5" cx="8" cy="8" r="7.5" stroke="#FD6266"/>
+    <rect x="7.55566" y="3.55566" width="1.15556" height="6.22222" fill="#FD6266" />
+    <path d="M7.57252 10.8974C7.44279 11.0463 7.37793 11.2313 7.37793 11.4523C7.37793 11.6685 7.44279 11.8487 7.57252 11.9929C7.70706 12.137 7.90886 12.2091 8.17793 12.2091C8.44219 12.2091 8.64159 12.137 8.77613 11.9929C8.91066 11.8487 8.97793 11.6685 8.97793 11.4523C8.97793 11.2313 8.91066 11.0463 8.77613 10.8974C8.64159 10.7436 8.44219 10.6667 8.17793 10.6667C7.90886 10.6667 7.70706 10.7436 7.57252 10.8974Z" fill="#FD6266"/>
+  </svg>
+;

--- a/src/modules/common-elements/labels.styles.less
+++ b/src/modules/common-elements/labels.styles.less
@@ -249,3 +249,14 @@
     }
   }
 }
+
+.PillLabel {
+  .mono-10;
+
+  align-items: center;
+  background: @color-highlight;
+  border-radius: 6px;
+  display: flex;
+  justify-content: center;
+  padding: 0 0.375rem;
+}

--- a/src/modules/common-elements/labels.tsx
+++ b/src/modules/common-elements/labels.tsx
@@ -43,6 +43,15 @@ export interface MovementIconProps {
   size: sizeTypes;
 }
 
+export interface MovementTextProps {
+  value: number;
+  size: sizeTypes;
+  showColors: boolean;
+  showBrackets: boolean;
+  showPercent: boolean;
+  showPlusMinus: boolean;
+}
+
 export interface PropertyLabelProps {
   label: string;
   value: string;
@@ -52,6 +61,10 @@ export interface PropertyLabelProps {
 export interface LinearPropertyLabelProps {
   label: string;
   value: string;
+}
+
+export interface PillLabelProps {
+  label: string;
 }
 
 export const PropertyLabel = (props: PropertyLabelProps) => (
@@ -140,7 +153,7 @@ export const PendingLabel = () => (
   </span>
 );
 
-const MovementIcon = (props: MovementIconProps) => {
+export const MovementIcon = (props: MovementIconProps) => {
   const getIconSizeStyles: Function = (size: sizeTypes): string =>
     classNames(Styles.MovementLabel_Icon, {
       [Styles.MovementLabel_Icon_small]: size == sizeTypes.SMALL,
@@ -160,16 +173,7 @@ const MovementIcon = (props: MovementIconProps) => {
   return <div className={`${iconSize} ${iconColor}`}>{MarketIcon}</div>;
 };
 
-export interface MovementTextProps {
-  value: number;
-  size: sizeTypes;
-  showColors: boolean;
-  showBrackets: boolean;
-  showPercent: boolean;
-  showPlusMinus: boolean;
-}
-
-const MovementText = (props: MovementTextProps) => {
+export const MovementText = (props: MovementTextProps) => {
   const getTextSizeStyle: Function = (size: sizeTypes): string =>
     classNames(Styles.MovementLabel_Text, {
       [Styles.MovementLabel_Text_small]: size == sizeTypes.SMALL,
@@ -263,3 +267,7 @@ export const MovementLabel = (props: MovementLabelProps) => {
     </div>
   );
 };
+
+export const PillLabel = (props: PillLabelProps) => (
+  <span className={Styles.PillLabel}>{props.label}</span>
+);

--- a/src/modules/common-elements/notifications.styles.less
+++ b/src/modules/common-elements/notifications.styles.less
@@ -1,0 +1,82 @@
+@import (reference) '~assets/styles/shared';
+
+.NotificationCard {
+  align-items: center;
+  background: @color-tertiary-background;
+  border: 1px solid fade(@color-highlight, 50%);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin: 4px;
+  padding: 16px 24px 13px 12px;
+}
+
+.NotificationCard__content {
+  margin: 0 1rem 0 0;
+}
+
+.NotificationCard__content__titleBar {
+  align-items: center;
+  display: flex;
+  margin: 0 0 4px;
+}
+
+.NotificationCard__content__Importance {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin: 0 8px 0 0;
+}
+
+.NotificationCard__content__title {
+  .text-12-bold;
+
+  color: @color-tertiary-text;
+  margin: 0 9px 0 0;
+}
+
+.NotificationCard__content__title__new {
+  color: @color-secondary-text;
+}
+
+.NotificationCard__content__message {
+  .text-11;
+
+  color: fade(@color-tertiary-text, 50%);
+
+  .NotificationCard__countdown__title {
+    color: fade(@color-tertiary-text, 50%);
+  }
+}
+
+.NotificationCard__content__message__new {
+  color: @color-secondary-text;
+
+  .NotificationCard__countdown__title {
+    color: @color-secondary-text;
+  }
+}
+
+.NotificationCard button {
+  min-height: 32px;
+}
+
+.NotificationCard__countdown {
+  display: flex;
+  flex-direction: column;
+  margin: 12px 0 0;
+}
+
+.NotificationCard__countdown__title {
+  .text-10;
+}
+
+.NotificationCard__countdown__timer {
+  .text-12-bold;
+
+  color: @color-in-reporting;
+}
+
+.NotificationCard__MarketName {
+  font-weight: @weight-bold;
+}

--- a/src/modules/common-elements/notifications.tsx
+++ b/src/modules/common-elements/notifications.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import classNames from "classnames";
+
+import * as constants from "modules/common-elements/constants";
+import { ImmediateImportance } from "modules/common-elements/icons";
+import { PillLabel } from "modules/common-elements/labels";
+import { CompactButton } from "modules/common-elements/buttons";
+
+import Styles from "modules/common-elements/notifications.styles";
+
+export interface NotificationProps {
+  isImportant: boolean;
+  isNew: boolean;
+  title: string;
+  buttonLabel: string;
+  buttonAction: Function;
+  children: React.StatelessComponent;
+}
+
+export const NotificationCard = (props: NotificationProps) => {
+  return (
+    <div className={Styles.NotificationCard}>
+      <div className={Styles.NotificationCard__content}>
+        <div className={Styles.NotificationCard__content__titleBar}>
+          {props.isImportant && (
+            <span className={Styles.NotificationCard__content__Importance}>
+              {ImmediateImportance}
+            </span>
+          )}
+          <span
+            className={classNames(Styles.NotificationCard__content__title, {
+              [Styles.NotificationCard__content__title__new]: props.isNew
+            })}
+          >
+            {props.title}
+          </span>
+          {props.isNew && <PillLabel label={constants.NEW} />}
+        </div>
+        <div
+          className={classNames(Styles.NotificationCard__content__message, {
+            [Styles.NotificationCard__content__message__new]: props.isNew
+          })}
+        >
+          {props.children}
+        </div>
+      </div>
+
+      <CompactButton
+        text={props.buttonLabel}
+        action={() => props.buttonAction()}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
### Add notification layout/templates
- Basic layout for Account Summary page
 -- scrollable collection, like the quads in the portfolio page, except this is one of 6.
 -- hide Menu / Sub Menu
- Added Notification-Box component
- Added PillLabel component
- Added Notifications component

<img width="1368" alt="screen shot 2019-02-25 at 9 41 17 am" src="https://user-images.githubusercontent.com/1683736/53349279-c8919e80-38ea-11e9-86a0-0a3dc60ab3bd.png">
<img width="462" alt="screen shot 2019-02-25 at 9 35 55 am" src="https://user-images.githubusercontent.com/1683736/53349303-d34c3380-38ea-11e9-9655-7b2daa138059.png">
