### PR TITLE
add Sell Complete Sets and Dispute notifications

### DIFF
--- a/src/modules/account/components/notifications/notifications-templates.tsx
+++ b/src/modules/account/components/notifications/notifications-templates.tsx
@@ -11,7 +11,7 @@ export interface TemplateProps {
   message: string;
   market: Market;
   currentTime: number;
-  reportingWindowEndtime: number;
+  reportingWindowEndtime: number | null;
 }
 
 export const Template = (props: TemplateProps) => {
@@ -36,7 +36,7 @@ export const Template = (props: TemplateProps) => {
   return (
     <React.Fragment>
       {body}
-      {marketStatus === "reporting" && (
+      {marketStatus === "reporting" && props.reportingWindowEndtime && (
         <div className={Styles.NotificationCard__countdown}>
           <MarketProgress
             reportingState={reportingState}
@@ -49,7 +49,6 @@ export const Template = (props: TemplateProps) => {
     </React.Fragment>
   );
 };
-
 
 export const OpenOrdersResolvedMarketsTemplate = (props: TemplateProps) => {
   const  { description } = props.market;
@@ -86,6 +85,33 @@ export const ReportEndingSoonTemplate = (props: TemplateProps) => {
       market={props.market}
       currentTime={props.currentTime}
       reportingWindowEndtime={props.reportingWindowEndtime}
+    />
+  );
+}
+
+export const DisputeTemplate = (props: TemplateProps) => {
+  const  { description, disputeInfo } = props.market;
+
+  return (
+    <Template
+      message={`Dispute round ${disputeInfo.disputeRound} for the market ${ description } is ending soon.`}
+      market={props.market}
+      currentTime={props.currentTime}
+      reportingWindowEndtime={props.reportingWindowEndtime}
+    />
+  );
+}
+
+export const SellCompleteSetTemplate = (props: TemplateProps) => {
+  const  { description, myPositionsSummary } = props.market;
+  const { numCompleteSets } = myPositionsSummary;
+
+  return (
+    <Template
+      message={`You currently have ${ numCompleteSets.full } of all outcomes for market: ${ description }. Please sell these complete sets.`}
+      market={props.market}
+      currentTime={props.currentTime}
+      reportingWindowEndtime={null}
     />
   );
 }

--- a/src/modules/account/components/notifications/notifications.tsx
+++ b/src/modules/account/components/notifications/notifications.tsx
@@ -6,6 +6,8 @@ import {
   FinalizeTemplate,
   OpenOrdersResolvedMarketsTemplate,
   ReportEndingSoonTemplate,
+  DisputeTemplate,
+  SellCompleteSetTemplate
 } from "modules/account/components/notifications/notifications-templates";
 
 import { Market, Notifications as INotifications  } from "modules/account/types";
@@ -15,6 +17,8 @@ export interface NotificationsProps {
   resolvedMarketsOpenOrders: Array<Market>;
   reportOnMarkets: Array<Market>;
   finalizedMarkets: Array<Market>;
+  marketsInDispute: Array<Market>;
+  completeSetPositions: Array<Market>;
   updateNotifications: Function;
   notifications: Array<INotifications>;
   currentAugurTimestamp: number;
@@ -29,6 +33,8 @@ class Notifications extends React.Component<NotificationsProps> {
   componentWillReceiveProps(nextProps: NotificationsProps) {
     if (!isEqual(nextProps.resolvedMarketsOpenOrders, this.props.resolvedMarketsOpenOrders) ||
         !isEqual(nextProps.reportOnMarkets, this.props.reportOnMarkets) ||
+        !isEqual(nextProps.marketsInDispute, this.props.marketsInDispute) ||
+        !isEqual(nextProps.completeSetPositions, this.props.completeSetPositions) ||
         !isEqual(nextProps.finalizedMarkets, this.props.finalizedMarkets)) {
           this.updateState(nextProps);
     }
@@ -36,9 +42,11 @@ class Notifications extends React.Component<NotificationsProps> {
 
   updateState(props: NotificationsProps) {
     this.props.updateNotifications(
-      this.generateCards(this.props.resolvedMarketsOpenOrders, 'resolvedMarketsOpenOrders')
-      .concat(this.generateCards(this.props.reportOnMarkets, 'reportOnMarkets'))
-      .concat(this.generateCards(this.props.finalizedMarkets, 'finalizedMarkets')));
+      this.generateCards(props.resolvedMarketsOpenOrders, 'resolvedMarketsOpenOrders')
+      .concat(this.generateCards(props.reportOnMarkets, 'reportOnMarkets'))
+      .concat(this.generateCards(props.finalizedMarkets, 'finalizedMarkets'))
+      .concat(this.generateCards(props.marketsInDispute, 'marketsInDispute'))
+      .concat(this.generateCards(props.completeSetPositions, 'sellCompleteSet')));
   }
 
   render() {
@@ -85,6 +93,26 @@ class Notifications extends React.Component<NotificationsProps> {
         Template: FinalizeTemplate
       }
     }
+    else if (type === 'marketsInDispute') {
+      defaults = {
+        isImportant: false,
+        isNew: false,
+        title: constants.TYPE_DISPUTE,
+        buttonLabel: constants.TYPE_DISPUTE,
+        buttonAction: () => null,
+        Template: DisputeTemplate
+      }
+    }
+    else if (type === 'sellCompleteSet') {
+      defaults = {
+        isImportant: false,
+        isNew: false,
+        title: constants.SELL_COMPLETE_SETS,
+        buttonLabel: constants.TYPE_VIEW,
+        buttonAction: () => null,
+        Template: SellCompleteSetTemplate
+      }
+    }
 
     return markets.map((market: Market) => {
       return {
@@ -96,3 +124,4 @@ class Notifications extends React.Component<NotificationsProps> {
 }
 
 export default Notifications;
+

--- a/src/modules/account/components/notifications/notifications.tsx
+++ b/src/modules/account/components/notifications/notifications.tsx
@@ -42,11 +42,11 @@ class Notifications extends React.Component<NotificationsProps> {
 
   updateState(props: NotificationsProps) {
     this.props.updateNotifications(
-      this.generateCards(props.resolvedMarketsOpenOrders, 'resolvedMarketsOpenOrders')
-      .concat(this.generateCards(props.reportOnMarkets, 'reportOnMarkets'))
-      .concat(this.generateCards(props.finalizedMarkets, 'finalizedMarkets'))
-      .concat(this.generateCards(props.marketsInDispute, 'marketsInDispute'))
-      .concat(this.generateCards(props.completeSetPositions, 'sellCompleteSet')));
+      this.generateCards(props.resolvedMarketsOpenOrders, constants.NOTIFICATION_TYPES.resolvedMarketsOpenOrders)
+      .concat(this.generateCards(props.reportOnMarkets, constants.NOTIFICATION_TYPES.reportOnMarkets))
+      .concat(this.generateCards(props.finalizedMarkets, constants.NOTIFICATION_TYPES.finalizedMarkets))
+      .concat(this.generateCards(props.marketsInDispute, constants.NOTIFICATION_TYPES.marketsInDispute))
+      .concat(this.generateCards(props.completeSetPositions, constants.NOTIFICATION_TYPES.sellCompleteSet)));
   }
 
   render() {
@@ -63,7 +63,7 @@ class Notifications extends React.Component<NotificationsProps> {
   generateCards(markets: Array<Market>, type: string) {
     let defaults = {};
 
-    if (type === 'resolvedMarketsOpenOrders') {
+    if (type === constants.NOTIFICATION_TYPES.resolvedMarketsOpenOrders) {
       defaults = {
         isImportant: false,
         isNew: false,
@@ -73,27 +73,27 @@ class Notifications extends React.Component<NotificationsProps> {
         Template: OpenOrdersResolvedMarketsTemplate
       }
     }
-    else if (type === 'reportOnMarkets') {
+    else if (type === constants.NOTIFICATION_TYPES.reportOnMarkets) {
       defaults = {
         isImportant: true,
         isNew: false,
-        title: constants.REPORTING_ENDS_SOON,
+        title: constants.REPORTING_ENDS_SOON_TITLE,
         buttonLabel: constants.TYPE_VIEW,
         buttonAction: () => null,
         Template: ReportEndingSoonTemplate
       }
     }
-    else if (type === 'finalizedMarkets') {
+    else if (type === constants.NOTIFICATION_TYPES.finalizedMarkets) {
       defaults = {
         isImportant: true,
         isNew: false,
-        title: constants.FINALIZE_MARKET,
+        title: constants.FINALIZE_MARKET_TITLE,
         buttonLabel: constants.TYPE_VIEW,
         buttonAction: () => null,
         Template: FinalizeTemplate
       }
     }
-    else if (type === 'marketsInDispute') {
+    else if (type === constants.NOTIFICATION_TYPES.marketsInDispute) {
       defaults = {
         isImportant: false,
         isNew: false,
@@ -103,11 +103,11 @@ class Notifications extends React.Component<NotificationsProps> {
         Template: DisputeTemplate
       }
     }
-    else if (type === 'sellCompleteSet') {
+    else if (type === constants.NOTIFICATION_TYPES.sellCompleteSet) {
       defaults = {
         isImportant: false,
         isNew: false,
-        title: constants.SELL_COMPLETE_SETS,
+        title: constants.SELL_COMPLETE_SETS_TITLE,
         buttonLabel: constants.TYPE_VIEW,
         buttonAction: () => null,
         Template: SellCompleteSetTemplate

--- a/src/modules/account/containers/notifications.ts
+++ b/src/modules/account/containers/notifications.ts
@@ -4,7 +4,10 @@ import {
   selectResolvedMarketsOpenOrders,
   selectReportOnMarkets,
   selectFinalizeMarkets,
+  selectMarketsInDispute,
+  selectCompleteSetPositions,
 } from "modules/notifications/selectors/notification-state";
+
 import { updateNotifications } from "modules/notifications/actions/update-notifications";
 
 // TODO create state Interface
@@ -12,20 +15,24 @@ const mapStateToProps = (state: any) => {
   const resolvedMarketsOpenOrders = selectResolvedMarketsOpenOrders(state);
   const reportOnMarkets = selectReportOnMarkets(state);
   const finalizedMarkets = selectFinalizeMarkets(state);
+  const marketsInDispute = selectMarketsInDispute(state);
+  const completeSetPositions = selectCompleteSetPositions(state);
 
   return {
     notifications: state.notifications,
     resolvedMarketsOpenOrders,
     reportOnMarkets,
     finalizedMarkets,
+    completeSetPositions,
+    marketsInDispute,
+    reportingFees: state.reportingWindowStats.reportingFees,
     currentAugurTimestamp: state.blockchain.currentAugurTimestamp,
     reportingWindowStatsEndTime: state.reportingWindowStats.endTime
   };
 };
 
 const mapDispatchToProps = (dispatch: Function) => ({
-  updateNotifications: (notifications: any) =>
-    dispatch(updateNotifications(notifications))
+  updateNotifications: (notifications: any) => dispatch(updateNotifications(notifications)),
 });
 
 const NotificationsContainer = connect(

--- a/src/modules/auth/actions/load-account-data.js
+++ b/src/modules/auth/actions/load-account-data.js
@@ -11,6 +11,7 @@ import getValue from "utils/get-value";
 import logError from "utils/log-error";
 import { loadUserMarketTradingHistory } from "modules/markets/actions/market-trading-history-management";
 import { loadDesignatedReporterMarkets } from "modules/reports/actions/load-designated-reporter-markets";
+import { loadDisputing } from "modules/reports/actions/load-disputing";
 
 const { ACCOUNT_TYPES } = augur.rpc.constants;
 
@@ -34,4 +35,5 @@ export const loadAccountData = (account, callback = logError) => dispatch => {
   dispatch(loadReportingWindowBounds());
   dispatch(loadUserMarketTradingHistory());
   dispatch(loadDesignatedReporterMarkets());
+  dispatch(loadDisputing());
 };

--- a/src/modules/common-elements/constants.ts
+++ b/src/modules/common-elements/constants.ts
@@ -553,9 +553,23 @@ export const VOLUME_ETH_SHARES = [
 export const NEW = "New";
 export const RESOLVED_MARKETS_OPEN_ORDERS_TITLE =
   "Open Orders in Resolved Market";
-export const REPORTING_ENDS_SOON =
+export const REPORTING_ENDS_SOON_TITLE =
   "Reporting Ends Soon";
-export const FINALIZE_MARKET =
+export const FINALIZE_MARKET_TITLE =
   "Finalize Market";
-export const SELL_COMPLETE_SETS =
+export const SELL_COMPLETE_SETS_TITLE =
   "Sell Complete Sets";
+
+export const OPEN_ORDERS_RESOLVED_MARKET = "resolvedMarketsOpenOrders";
+export const REPORT_ON_MARKET = "reportOnMarkets";
+export const FINALIZE_MARKET = "finalizedMarkets";
+export const MARKET_IN_DISPUTE = "marketsInDispute";
+export const SELL_COMPLETE_SET = "sellCompleteSet";
+
+export const NOTIFICATION_TYPES = {
+  [OPEN_ORDERS_RESOLVED_MARKET]: OPEN_ORDERS_RESOLVED_MARKET,
+  [REPORT_ON_MARKET]: REPORT_ON_MARKET,
+  [FINALIZE_MARKET]: FINALIZE_MARKET,
+  [MARKET_IN_DISPUTE]: MARKET_IN_DISPUTE,
+  [SELL_COMPLETE_SET]: SELL_COMPLETE_SET
+};

--- a/src/modules/common-elements/constants.ts
+++ b/src/modules/common-elements/constants.ts
@@ -557,3 +557,5 @@ export const REPORTING_ENDS_SOON =
   "Reporting Ends Soon";
 export const FINALIZE_MARKET =
   "Finalize Market";
+export const SELL_COMPLETE_SETS =
+  "Sell Complete Sets";

--- a/src/modules/common-elements/notifications.styles.less
+++ b/src/modules/common-elements/notifications.styles.less
@@ -51,6 +51,7 @@
 
   color: @color-tertiary-text;
   margin: 0 9px 0 0;
+  text-transform: capitalize;
 }
 
 .NotificationCard__content__title__new {
@@ -69,6 +70,7 @@
 
 .NotificationCard button {
   min-height: 32px;
+  text-transform: capitalize;
 }
 
 .NotificationCard__countdown {

--- a/src/modules/notifications/selectors/notification-state.js
+++ b/src/modules/notifications/selectors/notification-state.js
@@ -49,6 +49,51 @@ export const selectFinalizeMarkets = createSelector(
             market.reportingState ===
             constants.REPORTING_STATE.AWAITING_FINALIZATION
         )
+        .filter(
+          market => market.userPositions.length > 0 || address === market.author
+        )
+        .map(getRequiredMarketData);
+    }
+    return [];
+  }
+);
+
+// Get all the users markets where the user has COMPLETE SETS of SHARES
+export const selectCompleteSetPositions = createSelector(
+  selectMarkets,
+  markets => {
+    if (markets.length > 0) {
+      return markets
+        .filter(market => {
+          const numCompleteSets =
+            (market.myPositionsSummary &&
+              market.myPositionsSummary.numCompleteSets) ||
+            undefined;
+          return numCompleteSets && numCompleteSets.value > 0;
+        })
+        .map(getRequiredMarketData);
+    }
+    return [];
+  }
+);
+
+// Get all markets in dispute, for market creators and user with positions in disputed markets
+export const selectMarketsInDispute = createSelector(
+  selectMarkets,
+  selectLoginAccountAddress,
+  (markets, address) => {
+    if (markets.length > 0) {
+      return markets
+        .filter(
+          market =>
+            market.reportingState ===
+            constants.REPORTING_STATE.CROWDSOURCING_DISPUTE
+        )
+        .filter(
+          market =>
+            market.userPositions.length > 0 ||
+            market.designatedReporter === address
+        )
         .map(getRequiredMarketData);
     }
     return [];


### PR DESCRIPTION
### Add dispute/sell full shares notifications

<img src="https://user-images.githubusercontent.com/1683736/53887597-9ec62f00-3ff0-11e9-9267-85dc8705d646.png" width="400" />

@bthaile For showing disputeInfo for position holder users, I had to add ```dispatch(loadDisputing());``` to ```load-account-data.js```. I didn't notice a performance hit with this but please let me know if there is a more performant way to go about this.

