### PR TITLE
Fix UI issue of requiring more REP than needed for DR

### DIFF
--- a/src/modules/reporting/components/reporting-report/reporting-report.jsx
+++ b/src/modules/reporting/components/reporting-report/reporting-report.jsx
@@ -27,6 +27,7 @@ export default class ReportingReport extends Component {
     isMarketLoaded: PropTypes.bool.isRequired,
     isOpenReporting: PropTypes.bool.isRequired,
     isDesignatedReporter: PropTypes.bool.isRequired,
+    isDRMarketCreator: PropTypes.bool.isRequired,
     loadFullMarket: PropTypes.func.isRequired,
     location: PropTypes.object.isRequired,
     market: PropTypes.object.isRequired,
@@ -98,16 +99,25 @@ export default class ReportingReport extends Component {
   }
 
   calculateMarketCreationCosts() {
-    const { isOpenReporting, universe } = this.props;
+    const { isOpenReporting, universe, market, isDRMarketCreator } = this.props;
     // TODO: might have short-cut, designatedReportStake is on market from augur-node
     augur.createMarket.getMarketCreationCostBreakdown(
       { universe },
       (err, marketCreationCostBreakdown) => {
         if (err) return console.error(err);
 
-        const repAmount = formatEtherEstimate(
-          marketCreationCostBreakdown.designatedReportNoShowReputationBond
-        );
+        const { designatedReportStake } = market;
+        const {
+          designatedReportNoShowReputationBond
+        } = marketCreationCostBreakdown;
+
+        const neededStake = isDRMarketCreator
+          ? createBigNumber(designatedReportNoShowReputationBond).minus(
+              designatedReportStake
+            )
+          : designatedReportNoShowReputationBond;
+
+        const repAmount = formatEtherEstimate(neededStake);
 
         this.setState({
           stake: isOpenReporting ? "0" : repAmount.formatted

--- a/src/modules/reporting/containers/reporting-report.js
+++ b/src/modules/reporting/containers/reporting-report.js
@@ -61,12 +61,14 @@ const mergeProps = (sP, dP, oP) => {
   const isOpenReporting =
     market.reportingState === constants.REPORTING_STATE.OPEN_REPORTING;
   const isDesignatedReporter = market.designatedReporter === sP.userAddress;
+  const isDRMarketCreator = market.author === market.designatedReporter;
   return {
     ...oP,
     ...sP,
     marketId,
     isOpenReporting,
     isDesignatedReporter,
+    isDRMarketCreator,
     isLogged: sP.isLogged,
     isConnected: sP.isConnected && getValue(sP, "universe.id") != null,
     isMarketLoaded: sP.marketsData[marketId] != null,

--- a/src/modules/reporting/containers/reporting-report.js
+++ b/src/modules/reporting/containers/reporting-report.js
@@ -13,6 +13,7 @@ import getValue from "utils/get-value";
 import { submitInitialReport } from "modules/reports/actions/submit-initial-report";
 import { constants } from "services/augurjs";
 import { getGasPrice } from "modules/auth/selectors/get-gas-price";
+import { getUniverseInitialReporterStake } from "modules/universe/actions/load-universe-info";
 
 const mapStateToProps = state => ({
   isLogged: state.authStatus.isLogged,
@@ -47,7 +48,9 @@ const mapDispatchToProps = dispatch => ({
         returnPath,
         callback
       })
-    )
+    ),
+  getUniverseInitialReporterStake: (universe, cb) =>
+    dispatch(getUniverseInitialReporterStake(universe, cb))
 });
 
 const mergeProps = (sP, dP, oP) => {
@@ -90,7 +93,9 @@ const mergeProps = (sP, dP, oP) => {
         history,
         returnPath,
         callback
-      })
+      }),
+    getUniverseInitialReporterStake: (universe, cb) =>
+      dP.getUniverseInitialReporterStake(universe, cb)
   };
 };
 

--- a/src/modules/reports/actions/load-reporting.js
+++ b/src/modules/reports/actions/load-reporting.js
@@ -113,6 +113,6 @@ export const loadReporting = (marketIdsParam, callback = logError) => (
 
   Promise.all([openPromise, prePromise, designatedPromise]).then(errors => {
     const nonNullErrors = head(filter(errors, err => err !== null));
-    callback(nonNullErrors);
+    if (callback) callback(nonNullErrors);
   });
 };

--- a/src/modules/universe/actions/load-universe-info.js
+++ b/src/modules/universe/actions/load-universe-info.js
@@ -382,3 +382,10 @@ export function getUniverseProperties(universe, callback) {
     );
   };
 }
+
+export function getUniverseInitialReporterStake(universe, cb) {
+  augur.api.Universe.getOrCacheDesignatedReportStake(
+    { tx: { to: universe, send: false } },
+    (err, initialReporterStake) => cb(err, initialReporterStake)
+  );
+}


### PR DESCRIPTION
Calculate REP bond needed by designated reporter:

1. if market creator is same as designated reporter then amount needed is current dr stake amount - original no-show bond.

2. if designated reporter is not the same as market creator then designated reporter will need current dr stake amount.

fixes https://github.com/AugurProject/augur/issues/1260

