### PR TITLE
only show claim proceeds after CLAIM_PROCEEDS_WAIT_TIME

### DIFF
--- a/src/modules/account/components/notifications/notifications.tsx
+++ b/src/modules/account/components/notifications/notifications.tsx
@@ -96,8 +96,7 @@ class Notifications extends React.Component<NotificationsProps> {
         };
       } else if (notificaction.type === proceedsToClaim) {
         options = {
-          buttonAction: () =>
-            this.props.claimTradingProceeds(notificaction.markets),
+          buttonAction: () => this.props.claimTradingProceeds(),
           Template: ProceedsToClaimTemplate
         };
       }

--- a/src/modules/account/components/notifications/notifications.tsx
+++ b/src/modules/account/components/notifications/notifications.tsx
@@ -24,6 +24,7 @@ export interface NotificationsProps {
   reportingWindowStatsEndTime: number;
   sellCompleteSetsModal: Function;
   finalizeMarketModal: Function;
+  claimTradingProceeds: Function;
 }
 
 const {
@@ -95,7 +96,8 @@ class Notifications extends React.Component<NotificationsProps> {
         };
       } else if (notificaction.type === proceedsToClaim) {
         options = {
-          buttonAction: () => null,
+          buttonAction: () =>
+            this.props.claimTradingProceeds(notificaction.markets),
           Template: ProceedsToClaimTemplate
         };
       }

--- a/src/modules/account/containers/notifications.ts
+++ b/src/modules/account/containers/notifications.ts
@@ -6,7 +6,8 @@ import { getReportingFees } from "modules/reports/actions/get-reporting-fees";
 import { updateModal } from "modules/modal/actions/update-modal";
 import {
   MODAL_FINALIZE_MARKET,
-  MODAL_SELL_COMPLETE_SETS
+  MODAL_SELL_COMPLETE_SETS,
+  MODAL_CLAIM_PROCEEDS
 } from "modules/common-elements/constants";
 
 // TODO create state Interface
@@ -29,7 +30,9 @@ const mapDispatchToProps = (dispatch: Function) => ({
   sellCompleteSetsModal: (marketId: any, numCompleteSets: any) =>
     dispatch(
       updateModal({ type: MODAL_SELL_COMPLETE_SETS, marketId, numCompleteSets })
-    )
+    ),
+  claimTradingProceeds: (marketIds: any) =>
+    dispatch(updateModal({ type: MODAL_CLAIM_PROCEEDS, marketId: marketIds }))
 });
 
 const NotificationsContainer = connect(

--- a/src/modules/account/containers/notifications.ts
+++ b/src/modules/account/containers/notifications.ts
@@ -31,8 +31,8 @@ const mapDispatchToProps = (dispatch: Function) => ({
     dispatch(
       updateModal({ type: MODAL_SELL_COMPLETE_SETS, marketId, numCompleteSets })
     ),
-  claimTradingProceeds: (marketIds: any) =>
-    dispatch(updateModal({ type: MODAL_CLAIM_PROCEEDS, marketId: marketIds }))
+  claimTradingProceeds: () =>
+    dispatch(updateModal({ type: MODAL_CLAIM_PROCEEDS }))
 });
 
 const NotificationsContainer = connect(

--- a/src/modules/market/components/market-header/market-header-reporting.jsx
+++ b/src/modules/market/components/market-header/market-header-reporting.jsx
@@ -13,7 +13,7 @@ import {
   TYPE_DISPUTE,
   TYPE_REPORT
 } from "modules/common-elements/constants";
-import { createBigNumber } from "utils/create-big-number";
+import canClaimProceeds from "utils/can-claim-proceeds";
 
 export default class MarketHeaderReporting extends Component {
   static propTypes = {
@@ -60,16 +60,12 @@ export default class MarketHeaderReporting extends Component {
     } = market;
 
     let CatWinnerColorIndex = null;
-    let canClaim = false;
-    if (finalizationTime && outstandingReturns) {
-      const endTimestamp = createBigNumber(finalizationTime).plus(
-        createBigNumber(constants.CONTRACT_INTERVAL.CLAIM_PROCEEDS_WAIT_TIME)
-      );
-      const timeHasPassed = createBigNumber(currentTimestamp).minus(
-        endTimestamp
-      );
-      canClaim = timeHasPassed.toNumber() > 0;
-    }
+    const canClaim = canClaimProceeds(
+      finalizationTime,
+      outstandingReturns,
+      currentTimestamp
+    );
+
     if (market.marketType === CATEGORICAL) {
       if (tentativeWinner && tentativeWinner.id) {
         CatWinnerColorIndex = (parseInt(tentativeWinner.id, 10) + 1).toString();

--- a/src/modules/market/containers/market-header-reporting.js
+++ b/src/modules/market/containers/market-header-reporting.js
@@ -4,7 +4,7 @@ import { selectMarket } from "modules/markets/selectors/market";
 import MarketHeaderReporting from "modules/market/components/market-header/market-header-reporting";
 import { sendFinalizeMarket } from "modules/markets/actions/finalize-market";
 import marketDisputeOutcomes from "modules/reports/selectors/select-market-dispute-outcomes";
-import { selectCurrentTimestamp } from "src/select-state";
+import { selectCurrentTimestampInSeconds } from "src/select-state";
 import { updateModal } from "modules/modal/actions/update-modal";
 import { MODAL_CLAIM_TRADING_PROCEEDS } from "modules/common-elements/constants";
 
@@ -12,7 +12,7 @@ const mapStateToProps = (state, ownProps) => {
   const market = selectMarket(ownProps.marketId);
   const disputeOutcomes = marketDisputeOutcomes() || {};
   return {
-    currentTimestamp: selectCurrentTimestamp(state),
+    currentTimestamp: selectCurrentTimestampInSeconds(state),
     market,
     isLogged: state.authStatus.isLogged,
     isDesignatedReporter:

--- a/src/modules/notifications/selectors/notification-state.js
+++ b/src/modules/notifications/selectors/notification-state.js
@@ -4,7 +4,7 @@ import {
   selectLoginAccountAddress,
   selectReportingWindowStats,
   selectPendingLiquidityOrders,
-  selectCurrentTimestamp
+  selectCurrentTimestampInSeconds
 } from "src/select-state";
 
 import { createBigNumber } from "utils/create-big-number";
@@ -123,7 +123,7 @@ export const selectMarketsInDispute = createSelector(
 // Get all markets where the user has outstanding returns
 export const selectProceedsToClaim = createSelector(
   selectMarkets,
-  selectCurrentTimestamp,
+  selectCurrentTimestampInSeconds,
   (markets, currentTimestamp) => {
     if (markets.length > 0 && currentTimestamp) {
       return markets

--- a/src/utils/can-claim-proceeds.js
+++ b/src/utils/can-claim-proceeds.js
@@ -1,0 +1,22 @@
+import { createBigNumber } from "utils/create-big-number";
+import { constants } from "services/constants";
+
+// Check that the CLAIM_PROCEEDS_WAIT_TIME has passed since finalization
+export default function canClaimProceeds(
+  finalizationTime,
+  outstandingReturns,
+  currentTimestamp
+) {
+  let canClaim = false;
+  if (finalizationTime && outstandingReturns && currentTimestamp) {
+    const endTimestamp = createBigNumber(finalizationTime).plus(
+      createBigNumber(constants.CONTRACT_INTERVAL.CLAIM_PROCEEDS_WAIT_TIME)
+    );
+    const currentTimestampInSeconds = currentTimestamp / 1000;
+    const timeHasPassed = createBigNumber(currentTimestampInSeconds).minus(
+      endTimestamp
+    );
+    canClaim = timeHasPassed.toNumber() > 0;
+  }
+  return canClaim;
+}

--- a/src/utils/can-claim-proceeds.js
+++ b/src/utils/can-claim-proceeds.js
@@ -12,10 +12,7 @@ export default function canClaimProceeds(
     const endTimestamp = createBigNumber(finalizationTime).plus(
       createBigNumber(constants.CONTRACT_INTERVAL.CLAIM_PROCEEDS_WAIT_TIME)
     );
-    const currentTimestampInSeconds = currentTimestamp / 1000;
-    const timeHasPassed = createBigNumber(currentTimestampInSeconds).minus(
-      endTimestamp
-    );
+    const timeHasPassed = createBigNumber(currentTimestamp).minus(endTimestamp);
     canClaim = timeHasPassed.toNumber() > 0;
   }
   return canClaim;


### PR DESCRIPTION
Claim Proceeds was showing on the trading page without waiting for ```CLAIM_PROCEEDS_WAIT_TIME``` to pass.

The issue was we were using currentTimestamp (in ms, not seconds) with finalizationTime (in seconds). 

I also added this logic to the claim proceeds notification and wired up the modal.

See bug here ->
https://s3.amazonaws.com/img0.recordit.co/fWE0hmyJoo.mp4?AWSAccessKeyId=AKIAINSRFOQXTN4DT46A&Expires=1552575930&Signature=Vb2xi92j46mhspYD%2BdxqQa7vDzA%3D