### PR TITLE
remove all window resize event hooks

### DIFF
--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -236,8 +236,6 @@ export default class AppView extends Component {
   }
 
   componentDidMount() {
-    window.addEventListener("resize", this.handleWindowResize);
-
     this.checkIsMobile();
   }
 

--- a/src/modules/app/components/app/app.jsx
+++ b/src/modules/app/components/app/app.jsx
@@ -236,6 +236,8 @@ export default class AppView extends Component {
   }
 
   componentDidMount() {
+    window.addEventListener("resize", this.handleWindowResize);
+
     this.checkIsMobile();
   }
 

--- a/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick/market-outcome-charts--candlestick.jsx
@@ -48,20 +48,12 @@ class MarketOutcomeCandlestick extends React.PureComponent {
     this.updateVolumeType = this.updateVolumeType.bind(this);
   }
 
-  componentDidMount() {
-    window.addEventListener("resize", this.updateContainerWidths);
-  }
-
   componentWillReceiveProps(nextProps) {
     const containerWidths = this.getContainerWidths();
 
     this.setState({
       ...containerWidths
     });
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("resize", this.updateContainerWidths);
   }
 
   getContainerWidths() {

--- a/src/modules/market-charts/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
+++ b/src/modules/market-charts/components/market-outcome-charts--depth/market-outcome-charts--depth.jsx
@@ -79,8 +79,6 @@ export default class MarketOutcomeDepth extends Component {
       isMobile,
       hasOrders
     });
-
-    window.addEventListener("resize", this.drawDepthOnResize);
   }
 
   componentWillUpdate(nextProps, nextState) {
@@ -138,10 +136,6 @@ export default class MarketOutcomeDepth extends Component {
         containerWidth: nextState.containerWidth
       });
     }
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("resize", this.drawDepthOnResize);
   }
 
   drawDepth(options) {

--- a/src/modules/market-charts/components/market-outcomes-chart/market-outcome-chart-highchart.jsx
+++ b/src/modules/market-charts/components/market-outcomes-chart/market-outcome-chart-highchart.jsx
@@ -120,7 +120,6 @@ export default class MarketOutcomesChartHighchart extends Component {
   }
 
   componentDidMount() {
-    window.addEventListener("resize", this.onResize);
     const { bucketedPriceTimeSeries, selectedOutcome, daysPassed } = this.props;
     const { containerHeight } = this.state;
     this.buidOptions(
@@ -152,7 +151,6 @@ export default class MarketOutcomesChartHighchart extends Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener("resize", this.onResize);
     if (this.chart) {
       this.chart.destroy();
       this.chart = null;


### PR DESCRIPTION
remove resize event hooks, they aren't needed and just add to overhead.


https://github.com/AugurProject/augur/issues/1428
https://github.com/AugurProject/augur/issues/1392

also this PR is a performance improvement. Hooking to the resize didn't actually help charts resize. They resize each block as data comes in anyway.