### PR TITLE
Create selector market

### DIFF
--- a/src/modules/market/components/market-trading-form/market-trading-form.jsx
+++ b/src/modules/market/components/market-trading-form/market-trading-form.jsx
@@ -30,7 +30,8 @@ class MarketTradingForm extends Component {
     updateTradeCost: PropTypes.func.isRequired,
     updateTradeShares: PropTypes.func.isRequired,
     showSelectOutcome: PropTypes.func.isRequired,
-    toggleConnectionTray: PropTypes.func.isRequired
+    toggleConnectionTray: PropTypes.func.isRequired,
+    onSubmitPlaceTrade: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -91,7 +92,8 @@ class MarketTradingForm extends Component {
       updateTradeCost,
       updateTradeShares,
       showSelectOutcome,
-      toggleConnectionTray
+      toggleConnectionTray,
+      onSubmitPlaceTrade
     } = this.props;
     const s = this.state;
 
@@ -134,6 +136,7 @@ class MarketTradingForm extends Component {
           updateTradeCost={updateTradeCost}
           updateTradeShares={updateTradeShares}
           showSelectOutcome={showSelectOutcome}
+          onSubmitPlaceTrade={onSubmitPlaceTrade}
         />
         {initialMessage && (
           <div className={Styles["MarketTradingForm__initial-message"]}>

--- a/src/modules/market/containers/market-trading-form.js
+++ b/src/modules/market/containers/market-trading-form.js
@@ -8,7 +8,7 @@ import {
   updateTradeCost,
   updateTradeShares
 } from "modules/trades/actions/update-trade-cost-shares";
-
+import { placeTrade } from "modules/trades/actions/place-trade";
 import {
   updateAuthStatus,
   IS_CONNECTION_TRAY_OPEN
@@ -33,7 +33,25 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   updateTradeCost: (marketId, outcomeId, order, callback) =>
     dispatch(updateTradeCost({ marketId, outcomeId, ...order, callback })),
   updateTradeShares: (marketId, outcomeId, order, callback) =>
-    dispatch(updateTradeShares({ marketId, outcomeId, ...order, callback }))
+    dispatch(updateTradeShares({ marketId, outcomeId, ...order, callback })),
+  onSubmitPlaceTrade: (
+    marketId,
+    outcomeId,
+    tradeInProgress,
+    doNotCreateOrders,
+    callback,
+    onComplete
+  ) =>
+    dispatch(
+      placeTrade({
+        marketId,
+        outcomeId,
+        tradeInProgress,
+        doNotCreateOrders,
+        callback,
+        onComplete
+      })
+    )
 });
 
 const mergeProps = (sP, dP, oP) => ({

--- a/src/modules/markets/selectors/market.js
+++ b/src/modules/markets/selectors/market.js
@@ -164,8 +164,6 @@ const assembleMarket = (
   pendingOrders
 ) => {
   const marketId = marketData.id;
-
-  console.log("trigger market selector", marketId);
   const market = {
     ...marketData,
     description: marketData.description || "",

--- a/src/modules/markets/selectors/market.js
+++ b/src/modules/markets/selectors/market.js
@@ -469,22 +469,3 @@ const assembleMarket = (
   }
   return market;
 };
-
-export const selectMarketReport = (marketId, universeReports) => {
-  if (marketId && universeReports) {
-    const universeReportsMarketIds = Object.keys(universeReports);
-    const numUniverseReports = universeReportsMarketIds.length;
-    for (let i = 0; i < numUniverseReports; ++i) {
-      if (universeReports[universeReportsMarketIds[i]].marketId === marketId) {
-        return universeReports[universeReportsMarketIds[i]];
-      }
-    }
-  }
-};
-
-export const selectScalarMinimum = market => {
-  const scalarMinimum = {};
-  if (market && market.type === SCALAR)
-    scalarMinimum.minPrice = market.minPrice;
-  return scalarMinimum;
-};

--- a/src/modules/markets/selectors/market.js
+++ b/src/modules/markets/selectors/market.js
@@ -19,9 +19,8 @@ That way the market only gets re-assembled when that specific market outcomes ch
 
 This is true for all selectors, but especially important for this one.
 */
-
+import { createSelector } from "reselect";
 import { createBigNumber } from "utils/create-big-number";
-import memoize from "memoizee";
 import {
   formatShares,
   formatEther,
@@ -29,7 +28,6 @@ import {
   formatNumber
 } from "utils/format-number";
 import { convertUnixToFormattedDate } from "utils/format-date";
-import { selectCurrentTimestamp } from "src/select-state";
 import {
   YES_NO,
   CATEGORICAL,
@@ -45,7 +43,6 @@ import {
 
 import { constants } from "services/constants";
 import { getOutcomeName } from "utils/get-outcome";
-import { placeTrade } from "modules/trades/actions/place-trade";
 
 import store from "src/store";
 
@@ -67,45 +64,68 @@ import { selectReportableOutcomes } from "modules/reports/selectors/reportable-o
 
 import calculatePayoutNumeratorsValue from "utils/calculate-payout-numerators-value";
 import { selectFilledOrders } from "modules/orders/selectors/filled-orders";
+import {
+  selectMarketsDataState,
+  selectOutcomesDataState,
+  selectAccountTradesState,
+  selectMarketTradingHistoryState,
+  selectOrderBooksState,
+  selectOrderCancellationState,
+  selectPendingOrdersState,
+  selectLoginAccountState,
+  selectAccountShareBalance,
+  selectCurrentTimestamp
+} from "src/select-state";
 
 export const selectMarket = marketId => {
-  const {
-    marketsData,
-    outcomesData,
-    accountTrades,
-    marketTradingHistory,
-    orderBooks,
-    orderCancellation,
-    loginAccount,
-    accountShareBalances,
-    pendingOrders
-  } = store.getState();
-
-  const accountPositions = selectAccountPositions();
+  const marketsData = selectMarketsDataState(store.getState());
 
   if (!marketId || !marketsData || !marketsData[marketId]) {
     return {};
   }
 
-  return assembleMarket(
-    marketId,
-    marketsData[marketId],
-    marketTradingHistory[marketId],
-    outcomesData[marketId],
-    (accountPositions || {})[marketId] || {},
-    (accountTrades || {})[marketId],
-    orderBooks[marketId],
-    orderCancellation,
-    loginAccount.address,
-    (accountShareBalances || {})[marketId] || [],
-    (pendingOrders || {})[marketId],
-    store.dispatch
-  );
+  return getMarketSelector(store.getState(), marketId);
 };
 
-const assembleMarket = memoize(
+const selectMarketsDataStateMarket = (state, marketId) =>
+  selectMarketsDataState(state)[marketId];
+
+const selectMarketTradingHistoryStateMarket = (state, marketId) =>
+  selectMarketTradingHistoryState(state)[marketId];
+
+const selectOutcomesDataStateMarket = (state, marketId) =>
+  selectOutcomesDataState(state)[marketId];
+
+const selectAccountPositionsStateMarket = (state, marketId) =>
+  (selectAccountPositions(state) || {})[marketId] || {};
+
+const selectAccountTradesStateMarket = (state, marketId) =>
+  selectAccountTradesState(state)[marketId];
+
+const selectOrderBooksStateMarket = (state, marketId) =>
+  selectOrderBooksState(state)[marketId];
+
+const selectOrderCancellationStateMarket = (state, marketId) =>
+  selectOrderCancellationState(state)[marketId] || {};
+
+const selectAccountShareBalanceMarket = (state, marketId) =>
+  selectAccountShareBalance(state)[marketId];
+
+const selectPendingOrdersStateMarket = (state, marketId) =>
+  selectPendingOrdersState(state)[marketId];
+
+const getMarketSelector = createSelector(
+  selectMarketsDataStateMarket,
+  selectMarketTradingHistoryStateMarket,
+  selectOutcomesDataStateMarket,
+  selectAccountPositionsStateMarket,
+  selectAccountTradesStateMarket,
+  selectOrderBooksStateMarket,
+  selectOrderCancellationStateMarket,
+  selectLoginAccountState,
+  selectAccountShareBalanceMarket,
+  selectPendingOrdersStateMarket,
   (
-    marketId,
     marketData,
     marketPriceHistory,
     marketOutcomesData,
@@ -115,341 +135,341 @@ const assembleMarket = memoize(
     orderCancellation,
     accountAddress,
     accountShareBalances,
-    pendingOrders,
-    dispatch
-  ) => {
-    const market = {
-      ...marketData,
-      description: marketData.description || "",
-      id: marketId
+    pendingOrders
+  ) =>
+    assembleMarket(
+      marketData,
+      marketPriceHistory,
+      marketOutcomesData,
+      marketAccountPositions,
+      marketAccountTrades,
+      orderBooks,
+      orderCancellation,
+      accountAddress,
+      accountShareBalances,
+      pendingOrders
+    )
+);
+
+const assembleMarket = (
+  marketData,
+  marketPriceHistory,
+  marketOutcomesData,
+  marketAccountPositions,
+  marketAccountTrades,
+  orderBooks,
+  orderCancellation,
+  accountAddress,
+  accountShareBalances,
+  pendingOrders
+) => {
+  const marketId = marketData.id;
+
+  console.log("trigger market selector", marketId);
+  const market = {
+    ...marketData,
+    description: marketData.description || "",
+    id: marketId
+  };
+
+  if (typeof market.minPrice !== "undefined")
+    market.minPrice = createBigNumber(market.minPrice);
+  if (typeof market.maxPrice !== "undefined")
+    market.maxPrice = createBigNumber(market.maxPrice);
+
+  const now = new Date(selectCurrentTimestamp(store.getState()));
+
+  switch (market.marketType) {
+    case YES_NO:
+      market.isYesNo = true;
+      market.isCategorical = false;
+      market.isScalar = false;
+      delete market.scalarDenomination;
+      break;
+    case CATEGORICAL:
+      market.isYesNo = false;
+      market.isCategorical = true;
+      market.isScalar = false;
+      delete market.scalarDenomination;
+      break;
+    case SCALAR:
+      market.isYesNo = false;
+      market.isCategorical = false;
+      market.isScalar = true;
+      break;
+    default:
+      break;
+  }
+
+  market.endTime = convertUnixToFormattedDate(marketData.endTime);
+  market.endTimeLabel = market.endTime < now ? "expired" : "expires";
+  market.creationTime = convertUnixToFormattedDate(marketData.creationTime);
+
+  switch (market.reportingState) {
+    case constants.REPORTING_STATE.PRE_REPORTING:
+      market.marketStatus = MARKET_OPEN;
+      break;
+    case constants.REPORTING_STATE.AWAITING_FINALIZATION:
+    case constants.REPORTING_STATE.FINALIZED:
+      market.marketStatus = MARKET_CLOSED;
+      break;
+    default:
+      market.marketStatus = MARKET_REPORTING;
+      break;
+  }
+
+  market.reportingFeeRatePercent = formatPercent(
+    marketData.reportingFeeRate * 100,
+    {
+      positiveSign: false,
+      decimals: 4,
+      decimalsRounded: 4
+    }
+  );
+  market.marketCreatorFeeRatePercent = formatPercent(
+    marketData.marketCreatorFeeRate * 100,
+    {
+      positiveSign: false,
+      decimals: 4,
+      decimalsRounded: 4
+    }
+  );
+  market.settlementFeePercent = formatPercent(marketData.settlementFee * 100, {
+    positiveSign: false,
+    decimals: 4,
+    decimalsRounded: 4
+  });
+  market.openInterest = formatEther(marketData.openInterest, {
+    positiveSign: false
+  });
+  market.volume = formatEther(marketData.volume, {
+    positiveSign: false
+  });
+
+  market.resolutionSource = market.resolutionSource
+    ? market.resolutionSource
+    : undefined;
+
+  const numCompleteSets =
+    (accountShareBalances &&
+      accountShareBalances.length > 0 &&
+      Math.min.apply(null, accountShareBalances).toString()) ||
+    "0";
+
+  market.userPositions = Object.values(
+    marketAccountPositions.tradingPositions || []
+  ).map(position => {
+    const outcome = market.outcomes[position.outcome];
+    return {
+      ...positionSummary(position, outcome),
+      outcomeName: getOutcomeName(market, outcome)
     };
+  });
 
-    if (typeof market.minPrice !== "undefined")
-      market.minPrice = createBigNumber(market.minPrice);
-    if (typeof market.maxPrice !== "undefined")
-      market.maxPrice = createBigNumber(market.maxPrice);
-
-    const now = new Date(selectCurrentTimestamp(store.getState()));
-
-    switch (market.marketType) {
-      case YES_NO:
-        market.isYesNo = true;
-        market.isCategorical = false;
-        market.isScalar = false;
-        delete market.scalarDenomination;
-        break;
-      case CATEGORICAL:
-        market.isYesNo = false;
-        market.isCategorical = true;
-        market.isScalar = false;
-        delete market.scalarDenomination;
-        break;
-      case SCALAR:
-        market.isYesNo = false;
-        market.isCategorical = false;
-        market.isScalar = true;
-        break;
-      default:
-        break;
-    }
-
-    market.endTime = convertUnixToFormattedDate(marketData.endTime);
-    market.endTimeLabel = market.endTime < now ? "expired" : "expires";
-    market.creationTime = convertUnixToFormattedDate(marketData.creationTime);
-
-    switch (market.reportingState) {
-      case constants.REPORTING_STATE.PRE_REPORTING:
-        market.marketStatus = MARKET_OPEN;
-        break;
-      case constants.REPORTING_STATE.AWAITING_FINALIZATION:
-      case constants.REPORTING_STATE.FINALIZED:
-        market.marketStatus = MARKET_CLOSED;
-        break;
-      default:
-        market.marketStatus = MARKET_REPORTING;
-        break;
-    }
-
-    market.reportingFeeRatePercent = formatPercent(
-      marketData.reportingFeeRate * 100,
-      {
-        positiveSign: false,
-        decimals: 4,
-        decimalsRounded: 4
-      }
+  if (createBigNumber(numCompleteSets).gt(ZERO)) {
+    // need to remove all 0 positions
+    market.userPositions = market.userPositions.filter(
+      pos =>
+        !createBigNumber(pos.quantity.value).isEqualTo(ZERO) ||
+        !createBigNumber(pos.unrealizedNet.value).isEqualTo(ZERO) ||
+        !createBigNumber(pos.realizedNet.value).isEqualTo(ZERO)
     );
-    market.marketCreatorFeeRatePercent = formatPercent(
-      marketData.marketCreatorFeeRate * 100,
-      {
-        positiveSign: false,
-        decimals: 4,
-        decimalsRounded: 4
-      }
-    );
-    market.settlementFeePercent = formatPercent(
-      marketData.settlementFee * 100,
-      {
-        positiveSign: false,
-        decimals: 4,
-        decimalsRounded: 4
-      }
-    );
-    market.openInterest = formatEther(marketData.openInterest, {
-      positiveSign: false
-    });
-    market.volume = formatEther(marketData.volume, {
-      positiveSign: false
-    });
+  }
 
-    market.resolutionSource = market.resolutionSource
-      ? market.resolutionSource
-      : undefined;
-
-    market.onSubmitPlaceTrade = (
-      trade,
-      outcomeId,
-      callback,
-      onComplete,
-      doNotCreateOrders = false
-    ) =>
-      dispatch(
-        placeTrade({
-          marketId,
+  market.userOpenOrders =
+    Object.keys(marketOutcomesData || {})
+      .map(outcomeId =>
+        selectUserOpenOrders(
+          market.id,
           outcomeId,
-          tradeInProgress: trade,
-          doNotCreateOrders,
-          callback,
-          onComplete
-        })
-      );
-
-    const numCompleteSets =
-      (accountShareBalances &&
-        accountShareBalances.length > 0 &&
-        Math.min.apply(null, accountShareBalances).toString()) ||
-      "0";
-
-    market.userPositions = Object.values(
-      marketAccountPositions.tradingPositions || []
-    ).map(position => {
-      const outcome = market.outcomes[position.outcome];
-      return {
-        ...positionSummary(position, outcome),
-        outcomeName: getOutcomeName(market, outcome)
-      };
-    });
-
-    if (createBigNumber(numCompleteSets).gt(ZERO)) {
-      // need to remove all 0 positions
-      market.userPositions = market.userPositions.filter(
-        pos =>
-          !createBigNumber(pos.quantity.value).isEqualTo(ZERO) ||
-          !createBigNumber(pos.unrealizedNet.value).isEqualTo(ZERO) ||
-          !createBigNumber(pos.realizedNet.value).isEqualTo(ZERO)
-      );
-    }
-
-    market.userOpenOrders =
-      Object.keys(marketOutcomesData || {})
-        .map(outcomeId =>
-          selectUserOpenOrders(
-            market.id,
-            outcomeId,
-            orderBooks,
-            orderCancellation,
-            market.description,
-            getOutcomeName(market, marketOutcomesData[outcomeId])
-          )
+          orderBooks,
+          orderCancellation,
+          market.description,
+          getOutcomeName(market, marketOutcomesData[outcomeId])
         )
-        .filter(collection => collection.length !== 0)
-        .flat() || [];
+      )
+      .filter(collection => collection.length !== 0)
+      .flat() || [];
 
-    // add pending orders
-    if (pendingOrders && pendingOrders.length > 0) {
-      market.userOpenOrders = pendingOrders.concat(market.userOpenOrders);
-    }
+  // add pending orders
+  if (pendingOrders && pendingOrders.length > 0) {
+    market.userOpenOrders = pendingOrders.concat(market.userOpenOrders);
+  }
 
-    market.outcomes = Object.keys(marketOutcomesData || {})
-      .map(outcomeId => {
-        const outcomeData = marketOutcomesData[outcomeId];
-        const volume = createBigNumber(outcomeData.volume);
+  market.outcomes = Object.keys(marketOutcomesData || {})
+    .map(outcomeId => {
+      const outcomeData = marketOutcomesData[outcomeId];
+      const volume = createBigNumber(outcomeData.volume);
 
-        const outcome = {
-          ...outcomeData,
-          id: outcomeId,
-          marketId,
-          lastPrice: formatEther(outcomeData.price || 0, {
-            positiveSign: false
-          })
-        };
-        if (volume && volume.eq(ZERO)) {
-          outcome.lastPrice.formatted = "—";
-        }
-        if (market.isScalar) {
-          // note: not actually a percent
-          if (volume && volume.gt(ZERO)) {
-            outcome.lastPricePercent = formatNumber(outcome.lastPrice.value, {
-              decimals: 2,
-              decimalsRounded: 1,
-              denomination: "",
-              positiveSign: false,
-              zeroStyled: true
-            });
-            // format-number thinks 0 is '-', need to correct
-            if (outcome.lastPrice.fullPrecision === "0") {
-              outcome.lastPricePercent.formatted = "0";
-              outcome.lastPricePercent.full = "0";
-            }
-          } else {
-            const midPoint = createBigNumber(market.minPrice, 10)
-              .plus(createBigNumber(market.maxPrice, 10))
-              .dividedBy(2);
-            outcome.lastPricePercent = formatNumber(midPoint, {
-              decimals: 2,
-              decimalsRounded: 1,
-              denomination: "",
-              positiveSign: false,
-              zeroStyled: true
-            });
-          }
+      const outcome = {
+        ...outcomeData,
+        id: outcomeId,
+        marketId,
+        lastPrice: formatEther(outcomeData.price || 0, {
+          positiveSign: false
+        })
+      };
+      if (volume && volume.eq(ZERO)) {
+        outcome.lastPrice.formatted = "—";
+      }
+      if (market.isScalar) {
+        // note: not actually a percent
+        if (volume && volume.gt(ZERO)) {
+          outcome.lastPricePercent = formatNumber(outcome.lastPrice.value, {
+            decimals: 2,
+            decimalsRounded: 1,
+            denomination: "",
+            positiveSign: false,
+            zeroStyled: true
+          });
           // format-number thinks 0 is '-', need to correct
           if (outcome.lastPrice.fullPrecision === "0") {
             outcome.lastPricePercent.formatted = "0";
             outcome.lastPricePercent.full = "0";
           }
-        } else if (createBigNumber(outcome.volume || 0).gt(ZERO)) {
-          outcome.lastPricePercent = formatPercent(
-            outcome.lastPrice.value * 100,
-            {
-              positiveSign: false
-            }
-          );
         } else {
-          outcome.lastPricePercent = formatPercent(100 / market.numOutcomes, {
-            positiveSign: false
+          const midPoint = createBigNumber(market.minPrice, 10)
+            .plus(createBigNumber(market.maxPrice, 10))
+            .dividedBy(2);
+          outcome.lastPricePercent = formatNumber(midPoint, {
+            decimals: 2,
+            decimalsRounded: 1,
+            denomination: "",
+            positiveSign: false,
+            zeroStyled: true
           });
         }
-
-        market.filledOrders = selectFilledOrders(
-          marketPriceHistory,
-          accountAddress,
-          marketOutcomesData,
-          market,
-          market.userOpenOrders
-        )
-          .sort((a, b) => b.logIndex - a.logIndex)
-          .sort((a, b) => b.timestamp.timestamp - a.timestamp.timestamp);
-        market.recentlyTraded = convertUnixToFormattedDate(
-          market.filledOrders[0]
-            ? market.filledOrders[0].timestamp.timestamp
-            : 0
-        ); // the first one is the most recent
-
-        const orderBook = selectAggregateOrderBook(
-          outcome.id,
-          orderBooks,
-          orderCancellation
+        // format-number thinks 0 is '-', need to correct
+        if (outcome.lastPrice.fullPrecision === "0") {
+          outcome.lastPricePercent.formatted = "0";
+          outcome.lastPricePercent.full = "0";
+        }
+      } else if (createBigNumber(outcome.volume || 0).gt(ZERO)) {
+        outcome.lastPricePercent = formatPercent(
+          outcome.lastPrice.value * 100,
+          {
+            positiveSign: false
+          }
         );
-        outcome.orderBook = orderBook;
-        outcome.orderBookSeries = getOrderBookSeries(orderBook);
-        outcome.topBid = selectTopBid(orderBook, false);
-        outcome.topAsk = selectTopAsk(orderBook, false);
-
-        outcome.priceTimeSeries = selectPriceTimeSeries(
-          outcome,
-          marketPriceHistory
-        );
-
-        return outcome;
-      })
-      .sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
-
-    market.tags = (market.tags || []).filter(tag => !!tag);
-
-    market.unclaimedCreatorFees = formatEther(marketData.unclaimedCreatorFees);
-
-    market.marketCreatorFeesCollected = formatEther(
-      marketData.marketCreatorFeesCollected || 0
-    );
-
-    market.reportableOutcomes = selectReportableOutcomes(
-      market.marketType,
-      market.outcomes
-    );
-    const indeterminateOutcomeId =
-      market.type === YES_NO
-        ? YES_NO_INDETERMINATE_OUTCOME_ID
-        : CATEGORICAL_SCALAR_INDETERMINATE_OUTCOME_ID;
-    market.reportableOutcomes.push({
-      id: indeterminateOutcomeId,
-      name: INDETERMINATE_OUTCOME_NAME
-    });
-
-    if (
-      marketAccountTrades ||
-      (marketAccountPositions &&
-        marketAccountPositions.tradingPositionsPerMarket)
-    ) {
-      market.myPositionsSummary = {};
-      const marketPositions = marketAccountPositions.tradingPositionsPerMarket;
-      // leave complete sets here, until we finish new notifications
-      if (numCompleteSets) {
-        market.myPositionsSummary.numCompleteSets = formatShares(
-          numCompleteSets
-        );
+      } else {
+        outcome.lastPricePercent = formatPercent(100 / market.numOutcomes, {
+          positiveSign: false
+        });
       }
-      if (market.userPositions.length > 0) {
-        market.myPositionsSummary.currentValue = formatEther(
-          marketPositions.currentValue || ZERO
-        );
 
-        market.myPositionsSummary.totalReturns = formatEther(
-          marketPositions.total || ZERO
-        );
+      market.filledOrders = selectFilledOrders(
+        marketPriceHistory,
+        (accountAddress || {}).address,
+        marketOutcomesData,
+        market,
+        market.userOpenOrders
+      )
+        .sort((a, b) => b.logIndex - a.logIndex)
+        .sort((a, b) => b.timestamp.timestamp - a.timestamp.timestamp);
+      market.recentlyTraded = convertUnixToFormattedDate(
+        market.filledOrders[0] ? market.filledOrders[0].timestamp.timestamp : 0
+      ); // the first one is the most recent
 
-        market.myPositionsSummary.totalPercent = formatPercent(
-          marketPositions.totalPercent || ZERO
-        );
+      const orderBook = selectAggregateOrderBook(
+        outcome.id,
+        orderBooks,
+        orderCancellation
+      );
+      outcome.orderBook = orderBook;
+      outcome.orderBookSeries = getOrderBookSeries(orderBook);
+      outcome.topBid = selectTopBid(orderBook, false);
+      outcome.topAsk = selectTopAsk(orderBook, false);
 
-        market.myPositionsSummary.valueChange = formatPercent(
-          marketPositions.totalValue || ZERO
-        );
-      }
+      outcome.priceTimeSeries = selectPriceTimeSeries(
+        outcome,
+        marketPriceHistory
+      );
+
+      return outcome;
+    })
+    .sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
+
+  market.tags = (market.tags || []).filter(tag => !!tag);
+
+  market.unclaimedCreatorFees = formatEther(marketData.unclaimedCreatorFees);
+
+  market.marketCreatorFeesCollected = formatEther(
+    marketData.marketCreatorFeesCollected || 0
+  );
+
+  market.reportableOutcomes = selectReportableOutcomes(
+    market.marketType,
+    market.outcomes
+  );
+  const indeterminateOutcomeId =
+    market.type === YES_NO
+      ? YES_NO_INDETERMINATE_OUTCOME_ID
+      : CATEGORICAL_SCALAR_INDETERMINATE_OUTCOME_ID;
+  market.reportableOutcomes.push({
+    id: indeterminateOutcomeId,
+    name: INDETERMINATE_OUTCOME_NAME
+  });
+
+  if (
+    marketAccountTrades ||
+    (marketAccountPositions && marketAccountPositions.tradingPositionsPerMarket)
+  ) {
+    market.myPositionsSummary = {};
+    const marketPositions = marketAccountPositions.tradingPositionsPerMarket;
+    // leave complete sets here, until we finish new notifications
+    if (numCompleteSets) {
+      market.myPositionsSummary.numCompleteSets = formatShares(numCompleteSets);
     }
+    if (market.userPositions.length > 0) {
+      market.myPositionsSummary.currentValue = formatEther(
+        marketPositions.currentValue || ZERO
+      );
 
-    // Update the consensus object:
-    //   - formatted reported outcome
-    //   - the percentage of correct reports (for binaries only)
-    if (marketData.consensus) {
-      market.consensus = {
-        ...marketData.consensus
-      };
-      if (market.reportableOutcomes.length) {
-        const { payout, isInvalid } = market.consensus;
-        const winningOutcome = calculatePayoutNumeratorsValue(
-          market,
-          payout,
-          isInvalid
-        );
-        // for scalars, we will just use the winningOutcome for display
-        market.consensus.winningOutcome = winningOutcome;
-        const marketOutcome = market.reportableOutcomes.find(
-          outcome => outcome.id === winningOutcome
-        );
-        if (marketOutcome) market.consensus.outcomeName = marketOutcome.name;
-      }
-      if (market.consensus.proportionCorrect) {
-        market.consensus.percentCorrect = formatPercent(
-          createBigNumber(market.consensus.proportionCorrect, 10).times(100)
-        );
-      }
-    } else {
-      market.consensus = null;
+      market.myPositionsSummary.totalReturns = formatEther(
+        marketPositions.total || ZERO
+      );
+
+      market.myPositionsSummary.totalPercent = formatPercent(
+        marketPositions.totalPercent || ZERO
+      );
+
+      market.myPositionsSummary.valueChange = formatPercent(
+        marketPositions.totalValue || ZERO
+      );
     }
-    return market;
-  },
-  { max: 1 }
-);
+  }
+
+  // Update the consensus object:
+  //   - formatted reported outcome
+  //   - the percentage of correct reports (for binaries only)
+  if (marketData.consensus) {
+    market.consensus = {
+      ...marketData.consensus
+    };
+    if (market.reportableOutcomes.length) {
+      const { payout, isInvalid } = market.consensus;
+      const winningOutcome = calculatePayoutNumeratorsValue(
+        market,
+        payout,
+        isInvalid
+      );
+      // for scalars, we will just use the winningOutcome for display
+      market.consensus.winningOutcome = winningOutcome;
+      const marketOutcome = market.reportableOutcomes.find(
+        outcome => outcome.id === winningOutcome
+      );
+      if (marketOutcome) market.consensus.outcomeName = marketOutcome.name;
+    }
+    if (market.consensus.proportionCorrect) {
+      market.consensus.percentCorrect = formatPercent(
+        createBigNumber(market.consensus.proportionCorrect, 10).times(100)
+      );
+    }
+  } else {
+    market.consensus = null;
+  }
+  return market;
+};
 
 export const selectMarketReport = (marketId, universeReports) => {
   if (marketId && universeReports) {

--- a/src/modules/markets/selectors/market.js
+++ b/src/modules/markets/selectors/market.js
@@ -80,7 +80,12 @@ import {
 export const selectMarket = marketId => {
   const marketsData = selectMarketsDataState(store.getState());
 
-  if (!marketId || !marketsData || !marketsData[marketId]) {
+  if (
+    !marketId ||
+    !marketsData ||
+    !marketsData[marketId] ||
+    !marketsData[marketId].id
+  ) {
     return {};
   }
 

--- a/src/modules/markets/selectors/market.js
+++ b/src/modules/markets/selectors/market.js
@@ -73,8 +73,7 @@ import {
   selectOrderCancellationState,
   selectPendingOrdersState,
   selectLoginAccountState,
-  selectAccountShareBalance,
-  selectCurrentTimestamp
+  selectAccountShareBalance
 } from "src/select-state";
 
 export const selectMarket = marketId => {
@@ -180,8 +179,6 @@ const assembleMarket = (
   if (typeof market.maxPrice !== "undefined")
     market.maxPrice = createBigNumber(market.maxPrice);
 
-  const now = new Date(selectCurrentTimestamp(store.getState()));
-
   switch (market.marketType) {
     case YES_NO:
       market.isYesNo = true;
@@ -205,7 +202,6 @@ const assembleMarket = (
   }
 
   market.endTime = convertUnixToFormattedDate(marketData.endTime);
-  market.endTimeLabel = market.endTime < now ? "expired" : "expires";
   market.creationTime = convertUnixToFormattedDate(marketData.creationTime);
 
   switch (market.reportingState) {

--- a/src/modules/markets/selectors/markets-all.js
+++ b/src/modules/markets/selectors/markets-all.js
@@ -1,19 +1,6 @@
 import { createSelector } from "reselect";
 import store from "src/store";
-import {
-  selectMarketsDataState,
-  selectFavoritesState,
-  selectReportsState,
-  selectOutcomesDataState,
-  selectAccountTradesState,
-  selectUniverseState,
-  selectMarketTradingHistoryState,
-  selectOrderBooksState,
-  selectOrderCancellationState,
-  selectSmallestPositionsState,
-  selectLoginAccountState
-} from "src/select-state";
-import selectAccountPositions from "modules/orders/selectors/positions-plus-asks";
+import { selectMarketsDataState } from "src/select-state";
 
 import { selectMarket } from "modules/markets/selectors/market";
 
@@ -23,32 +10,7 @@ export default function() {
 
 export const selectMarkets = createSelector(
   selectMarketsDataState,
-  selectFavoritesState,
-  selectReportsState,
-  selectOutcomesDataState,
-  selectAccountPositions,
-  selectAccountTradesState,
-  selectUniverseState,
-  selectMarketTradingHistoryState,
-  selectOrderBooksState,
-  selectOrderCancellationState,
-  selectSmallestPositionsState,
-  selectLoginAccountState,
-  (
-    marketsData,
-    favorites,
-    reports,
-    outcomesData,
-    accountPositions,
-    accountTrades,
-    universe,
-    selectedFilterSort,
-    marketTradingHistory,
-    orderBooks,
-    orderCancellation,
-    smallestPositions,
-    loginAccount
-  ) => {
+  marketsData => {
     if (!marketsData) return [];
     return Object.keys(marketsData).map(marketId => {
       if (!marketId || !marketsData[marketId]) return {};

--- a/src/modules/orders/selectors/open-orders.js
+++ b/src/modules/orders/selectors/open-orders.js
@@ -8,5 +8,8 @@ export default function() {
 
 export const selectOpenOrdersMarkets = createSelector(
   selectAllMarkets,
-  markets => markets.filter(market => market.userOpenOrders.length)
+  markets =>
+    markets.filter(
+      market => market.userOpenOrders && market.userOpenOrders.length
+    )
 );

--- a/src/modules/trading/components/trading--wrapper/trading--wrapper.jsx
+++ b/src/modules/trading/components/trading--wrapper/trading--wrapper.jsx
@@ -33,7 +33,8 @@ class TradingWrapper extends Component {
     toggleMobileView: PropTypes.func.isRequired,
     updateTradeCost: PropTypes.func.isRequired,
     updateTradeShares: PropTypes.func.isRequired,
-    showSelectOutcome: PropTypes.func.isRequired
+    showSelectOutcome: PropTypes.func.isRequired,
+    onSubmitPlaceTrade: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -287,7 +288,8 @@ class TradingWrapper extends Component {
       handleFilledOnly,
       updateSelectedOutcome,
       toggleMobileView,
-      showSelectOutcome
+      showSelectOutcome,
+      onSubmitPlaceTrade
     } = this.props;
     const s = this.state;
     const {
@@ -425,9 +427,11 @@ class TradingWrapper extends Component {
             type={selectedNav}
             action={e => {
               e.preventDefault();
-              market.onSubmitPlaceTrade(
-                s.trade,
+              onSubmitPlaceTrade(
+                market.id,
                 selectedOutcome.id,
+                s.trade,
+                s.doNotCreateOrders,
                 (err, tradeGroupID) => {
                   // onSent/onFailed CB
                   if (!err) {
@@ -438,8 +442,7 @@ class TradingWrapper extends Component {
                   if (s.doNotCreateOrders && res.res !== res.sharesToFill)
                     handleFilledOnly(res.tradeInProgress);
                   // onComplete CB
-                },
-                s.doNotCreateOrders
+                }
               );
             }}
             disabled={!s.trade || !s.trade.limitPrice}

--- a/src/select-state.js
+++ b/src/select-state.js
@@ -53,6 +53,7 @@ export const selectUniverseState = state => state.universe;
 export const selectUrlState = state => state.url;
 export const selectPendingLiquidityOrders = state =>
   state.pendingLiquidityOrders;
+export const selectAccountShareBalance = state => state.accountShareBalances;
 
 export const selectCurrentTimestamp = createSelector(
   selectBlockchainState,


### PR DESCRIPTION
moved dispatched method out of market selector so dispatch isn't needed to be passed in.

set up simple selectors to return market specific data from state collections.

This is a jumping off point for more complex ways to do cacheing of selectors. I restructured the market selector, not much of a performance boost, most improvement is the selector actually stops triggering if the UI just sits there, until a new block comes in. so I don't think we have big leaks


continued performance task and when user connects
https://github.com/AugurProject/augur/issues/1284