### PR TITLE
timezone verbiage tweaks, updated reporting labeling

### DIFF
--- a/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card.jsx
+++ b/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card.jsx
@@ -152,12 +152,15 @@ export default class MarketPortfolioCard extends Component {
           >
             <div className={Styles.MarketCard__headertext}>
               <span className={Styles["MarketCard__expiration--mobile"]}>
-                {dateHasPassed(currentTimestamp, market.endTime.timestamp)
+                {dateHasPassed(
+                  currentTimestamp,
+                  (market.endTime || {}).timestamp
+                )
                   ? "Reporting Started "
                   : "Reporting Starts "}
                 {isMobile
-                  ? market.endTime.formattedLocalShort
-                  : market.endTime.formattedLocal}
+                  ? (market.endTime || {}).formattedLocalShort
+                  : (market.endTime || {}).formattedLocal}
               </span>
               <h1 className={CommonStyles.MarketCommon__description}>
                 <MarketLink id={market.id}>{market.description}</MarketLink>

--- a/src/modules/reporting/components/common/invalid-message.jsx
+++ b/src/modules/reporting/components/common/invalid-message.jsx
@@ -19,7 +19,10 @@ const InvalidMessage = () => (
       </span>
       <ul>
         <li>The question is subjective in nature</li>
-        <li>The outcome was not known at reporting start time</li>
+        <li>
+          Reporting Start Time must not conflict with the Market Question or
+          Additional Details.
+        </li>
         <li>
           The title, details, reporting start time, resolution source, and
           outcomes are in direct conflict

--- a/src/modules/reporting/components/reporting-report-confirm/reporting-report-confirm.jsx
+++ b/src/modules/reporting/components/reporting-report-confirm/reporting-report-confirm.jsx
@@ -1,15 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { BigNumber } from "utils/create-big-number";
 
 import ConfirmStyles from "modules/common/less/confirm-table";
 
 const ReportingReportConfirm = ({
   selectedOutcome,
   stake,
+  stakeLabel,
   gasEstimate,
   isMarketInValid,
-  isOpenReporting,
+  isDesignatedReporter,
   designatedReportNoShowReputationBond
 }) => (
   <article className={ConfirmStyles.Confirm}>
@@ -23,14 +23,10 @@ const ReportingReportConfirm = ({
               {isMarketInValid ? "Market is Invalid" : selectedOutcome}
             </span>
           </li>
-          {!isOpenReporting && (
-            <li>
-              <span>Stake</span>
-              <span>
-                {BigNumber.isBigNumber(stake) ? stake.toNumber() : stake} REP
-              </span>
-            </li>
-          )}
+          <li>
+            <span>{stakeLabel}</span>
+            <span>{stake} REP</span>
+          </li>
           <li>
             <span>Gas</span>
             <span>{gasEstimate} ETH</span>
@@ -38,7 +34,7 @@ const ReportingReportConfirm = ({
         </ul>
       </div>
     </div>
-    {isOpenReporting &&
+    {!isDesignatedReporter &&
       designatedReportNoShowReputationBond && (
         <div className={ConfirmStyles.Confirm__note_text}>
           If your report is accepted as the winning outcome, you will receive at
@@ -51,9 +47,10 @@ const ReportingReportConfirm = ({
 ReportingReportConfirm.propTypes = {
   selectedOutcome: PropTypes.string.isRequired,
   stake: PropTypes.string.isRequired,
+  stakeLabel: PropTypes.string.isRequired,
   gasEstimate: PropTypes.string.isRequired,
   isMarketInValid: PropTypes.bool.isRequired,
-  isOpenReporting: PropTypes.bool.isRequired,
+  isDesignatedReporter: PropTypes.bool.isRequired,
   designatedReportNoShowReputationBond: PropTypes.object
 };
 

--- a/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
+++ b/src/modules/reporting/components/reporting-report-form/reporting-report-form.jsx
@@ -24,6 +24,7 @@ export default class ReportingReportForm extends Component {
     selectedOutcome: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
       .isRequired,
     stake: PropTypes.string.isRequired,
+    stakeLabel: PropTypes.string.isRequired,
     isOpenReporting: PropTypes.bool.isRequired,
     isDesignatedReporter: PropTypes.bool.isRequired,
     isMarketInValid: PropTypes.bool,
@@ -179,6 +180,7 @@ export default class ReportingReportForm extends Component {
       market,
       selectedOutcome,
       stake,
+      stakeLabel,
       validations,
       insufficientRep,
       isDesignatedReporter
@@ -340,7 +342,7 @@ export default class ReportingReportForm extends Component {
         {(!isOpenReporting || isDesignatedReporter) && (
           <li>
             <label htmlFor="sr__input--stake">
-              <span>Required Stake</span>
+              <span>{stakeLabel}</span>
             </label>
             <p>{stake} REP</p>
           </li>

--- a/src/modules/reporting/components/reporting-report/reporting-report.jsx
+++ b/src/modules/reporting/components/reporting-report/reporting-report.jsx
@@ -10,6 +10,7 @@ import {
   formatRep,
   formatAttoEth
 } from "utils/format-number";
+import { ZERO } from "modules/trades/constants/numbers";
 import MarketPreview from "modules/market/containers/market-preview";
 import NullStateMessage from "modules/common/components/null-state-message/null-state-message";
 import ReportingReportForm from "modules/reporting/components/reporting-report-form/reporting-report-form";
@@ -49,7 +50,7 @@ export default class ReportingReport extends Component {
       selectedOutcomeName: "",
       // need to get value from augur-node for
       // designated reporter or initial reporter (open reporting)
-      stake: "0",
+      stake: formatRep("0"),
       validations: {
         selectedOutcome: null
       },
@@ -122,7 +123,7 @@ export default class ReportingReport extends Component {
         const repAmount = formatEtherEstimate(neededStake);
 
         this.setState({
-          stake: isDesignatedReporter ? repAmount.formatted : "0"
+          stake: isDesignatedReporter ? repAmount : formatRep("0")
         });
       }
     );
@@ -164,7 +165,7 @@ export default class ReportingReport extends Component {
     } = this.props;
     const s = this.state;
 
-    const BNstake = createBigNumber(formatRep(s.stake).fullPrecision);
+    const BNstake = createBigNumber(s.stake.fullPrecision);
     const insufficientRep = !isOpenReporting
       ? createBigNumber(availableRep).lt(BNstake)
       : false;
@@ -172,6 +173,13 @@ export default class ReportingReport extends Component {
       !Object.keys(s.validations).every(key => s.validations[key] === true) ||
       insufficientRep ||
       (!isDesignatedReporter && !isOpenReporting);
+    let stakeLabel = "Required Stake";
+    let stakeValue = s.stake.formatted;
+    if (createBigNumber(s.stake.fullPrecision).lt(ZERO)) {
+      stakeLabel = "REP STAKE RETURNS";
+      stakeValue = formatRep(createBigNumber(s.stake.fullPrecision).abs())
+        .formatted;
+    }
     return (
       <section>
         <Helmet>
@@ -201,7 +209,8 @@ export default class ReportingReport extends Component {
                     updateState={this.updateState}
                     isMarketInValid={s.isMarketInValid}
                     selectedOutcome={s.selectedOutcome}
-                    stake={s.stake}
+                    stake={stakeValue}
+                    stakeLabel={stakeLabel}
                     validations={s.validations}
                     isOpenReporting={isOpenReporting}
                     insufficientRep={insufficientRep}
@@ -216,11 +225,12 @@ export default class ReportingReport extends Component {
                 market={market}
                 isMarketInValid={s.isMarketInValid}
                 selectedOutcome={s.selectedOutcomeName}
-                stake={s.stake}
+                stake={stakeValue}
+                stakeLabel={stakeLabel}
                 designatedReportNoShowReputationBond={
                   s.designatedReportNoShowReputationBond
                 }
-                isOpenReporting={isOpenReporting}
+                isDesignatedReporter={isDesignatedReporter}
                 gasEstimate={s.gasEstimate}
               />
             )}


### PR DESCRIPTION
added some defensive code when market object doesn't have properties fixed reporting to tell user if they require stake or are getting returns


https://github.com/AugurProject/augur/issues/1600


updated some timezone verbiage 
updated REP stake label when designated reporter and they get REP returns.
show required REP label on reporting by default. 