### PR TITLE
changes release to use azure pipelines from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,7 @@ services:
 branches:
   only:
     - master
-    - stable
-    - sneakpeak
-    - mvp
-    - petong/travis-ci
-    - "/^v\\d+\\.\\d+\\.\\d$/"
 node_js:
-  - '9'
   - '10.15.0'
 addons:
   apt:
@@ -30,62 +24,7 @@ script:
   # This is here to confirm the build works.
   # Nothing is done with the resulting artifacts.
   - yarn build --dev
-jobs:
-  include:
-  - stage: Deploy to stable
-    if: (branch = stable) AND (NOT (type IN (pull_request)))
-    script: skip
-    deploy:
-      provider: script
-      script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; npm run docker:release -- stable
-      skip_cleanup: true
-      on:
-        all_branches: true
-  - stage: Deploy to sneakpeak
-    if: (branch = sneakpeak) AND (NOT (type IN (pull_request)))
-    script: skip
-    deploy:
-      provider: script
-      script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; npm run docker:release -- sneakpeak
-      skip_cleanup: true
-      on:
-        all_branches: true
-  - stage: Deploy to dev
-    if: (branch = master) AND (NOT (type IN (pull_request)))
-    script: skip
-    deploy:
-      provider: script
-      script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; npm run docker:release -- dev
-      skip_cleanup: true
-      on:
-        all_branches: true
-  - stage: Deploy to kovan
-    if: (branch = master) AND (NOT (type IN (pull_request)))
-    script: skip
-    deploy:
-      provider: script
-      script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; npm run docker:release -- kovan
-      skip_cleanup: true
-      on:
-        all_branches: true
-  - stage: Deploy optimized build
-    if: (branch = master) AND (NOT (type IN (pull_request)))
-    script: skip
-    deploy:
-      provider: script
-      script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; npm run docker:release -- dev-optimized
-      skip_cleanup: true
-      on:
-        all_branches: true
-  - stage: Build docker release
-    if: tag = true
-    script: skip
-    deploy:
-      provider: script
-      script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; npm run docker:release -- release
-      skip_cleanup: true
-      on:
-        all_branches: true
+
 env:
   global:
     - DOCKER_USERNAME=augurintegration

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:10.15.0-alpine as builder
+ARG NODE_VERSION=10.15.0
+FROM node:${NODE_VERSION}-alpine as builder
 
 ENV PATH /root/.yarn/bin:$PATH
 ARG ethereum_network=rinkeby
@@ -19,6 +20,7 @@ RUN apk --no-cache add \
 
 # begin create caching layer
 COPY package.json /augur/package.json
+ADD https://nodejs.org/download/release/v${NODE_VERSION}/node-v${NODE_VERSION}-headers.tar.gz /augur/node-v${NODE_VERSION}-headers.tar.gz
 WORKDIR /augur
 RUN git init \
   && yarn add require-from-string \
@@ -49,7 +51,10 @@ RUN git rev-parse HEAD > /augur/build/git-hash.txt \
   && chmod 755 /augur/local-run.sh \
   && cd /augur
 
-RUN rm -rf node_modules && yarn install --production
+RUN rm -rf node_modules && \
+    npm config set loglevel silly && \
+    npm config set tarball /augur/node-v${NODE_VERSION}-headers.tar.gz && \
+    yarn install --production
 
 FROM node:10.15.0-alpine
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,9 @@
+variables:
+  NODE_JS_VERSION: 10.15.0
+
 trigger:
 - master
+- azure/*
 
 jobs:
   - job: test_ui
@@ -8,10 +12,98 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: 10.15
-      - script: yarn
-      - script: yarn lint && yarn test
+          versionSpec: $(NODE_JS_VERSION)
+      - bash: |
+          yarn
+          yarn lint
+          yarn test
           # This is here to confirm the build works.
           # Nothing is done with the resulting artifacts.
-      - script: yarn build --dev
-        displayName: 'lint and test'
+          yarn build --dev
+        displayName: 'lint, test, and build'
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: 'junit.xml'
+
+  - job: deploy_ui_on_master
+    dependsOn:
+      - test_ui
+    strategy:
+      maxParallel: 3
+      matrix:
+        dev:
+          RELEASE_ENV: dev
+        kovan:
+          RELEASE_ENV: kovan
+        dev-optimized:
+          RELEASE_ENV: dev-optimized
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.6.5'
+      - task: NodeTool@0
+        inputs:
+          versionSpec: $(NODE_JS_VERSION)
+      - task: Docker@1
+        displayName: docker login
+        inputs:
+          command: login
+          containerRegistryType: Container Registry
+          dockerRegistryEndpoint: dockerhub-augurproject
+      - bash: |
+          set -euxo pipefail
+          npm run docker:release -- $(RELEASE_ENV)
+        displayName: docker release $(RELEASE_ENV)
+        env:
+          AWS_ACCESS_KEY_ID: $(AWS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_KEY)
+      - task: Docker@1
+        displayName: docker logout
+        inputs:
+          command: logout
+          containerRegistryType: Container Registry
+          dockerRegistryEndpoint: dockerhub-augurproject
+    condition: |
+      and
+      (
+          succeeded(),
+          eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      )
+
+  - job: deploy_ui_on_sneakpreview
+    dependsOn:
+      - test_ui
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.6.5'
+      - task: NodeTool@0
+        inputs:
+          versionSpec: $(NODE_JS_VERSION)
+      - task: Docker@1
+        displayName: docker login
+        inputs:
+          command: login
+          containerRegistryType: Container Registry
+          dockerRegistryEndpoint: dockerhub-augurproject
+      - bash: |
+          set -euxo pipefail
+          npm run docker:release -- sneakpeak
+        displayName: docker release sneakpeak
+        env:
+          AWS_ACCESS_KEY_ID: $(AWS_KEY_ID)
+          AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_KEY)
+      - task: Docker@1
+        displayName: docker logout
+        inputs:
+          command: logout
+          containerRegistryType: Container Registry
+          dockerRegistryEndpoint: dockerhub-augurproject
+    condition: |
+      and
+      (
+          succeeded(),
+          eq(variables['Build.SourceBranch'], 'refs/heads/sneakpeak')
+      )
+

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -56,7 +56,7 @@ case ${augur_env} in
         ;;
 esac
 
-docker build . --build-arg ethereum_network=${network} --build-arg build_environment=${build_environment} --tag augurproject/augur:${augur_env} --tag augurproject/augur:$version || exit 1
+docker build . --build-arg ethereum_network=${network} --build-arg build_environment=${build_environment} --cache-from augurproject/augur:${augur_env} --tag augurproject/augur:${augur_env} --tag augurproject/augur:$version
 
 docker push augurproject/augur:$version
 docker push augurproject/augur:${augur_env}


### PR DESCRIPTION
this change will still run tests on travis in addition to azure pipelines, but changes to master or sneakpeak will result in a deploy, to be done on azure pipelines instead of travis.