### PR TITLE
tooltip runs off screen when mobile 

### DIFF
--- a/src/modules/common/less/tooltip.styles.less
+++ b/src/modules/common/less/tooltip.styles.less
@@ -37,6 +37,10 @@
   border-radius: 3px !important;
   max-width: 20rem;
   padding: 0.75rem !important;
+
+  @media @breakpoint-mobile {
+    max-width: 15rem;
+  }
 }
 
 .TooltipHint {


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/1633

![image](https://user-images.githubusercontent.com/3970376/55963926-49a5ba80-5c39-11e9-8761-ed9d19ef0154.png)

Narrow the tooltip for mobile.

![image](https://user-images.githubusercontent.com/3970376/55963971-6641f280-5c39-11e9-8e63-21ef929b5f0c.png)


![image](https://user-images.githubusercontent.com/3970376/55963869-34c92700-5c39-11e9-9989-62196f0c17ec.png)


![image](https://user-images.githubusercontent.com/3970376/55963903-3db9f880-5c39-11e9-9144-325952f2cc64.png)



