### PR TITLE
Adds publishing on tag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.com
+always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 registry=https://registry.npmjs.com
-always-auth=true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,6 +155,9 @@ jobs:
           command: logout
           containerRegistryType: Container Registry
           dockerRegistryEndpoint: dockerhub-augurproject
+      - task: npmAuthenticate@0
+        inputs:
+          customEndpoint: npmjs-augur-integration
       - task: Npm@1
         inputs:
           command: 'custom' # Options: install, publish, custom

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,7 @@ jobs:
             if [[ $current_tag =~ $LATEST_VERSION_REGEX ]]; then
               echo "##vso[task.setvariable variable=npm_tag]latest"
               npm run docker:release -- release
-            elsif [[ $current_tag =~ $DEV_VERSION_REGEX ]]; then
+            elif [[ $current_tag =~ $DEV_VERSION_REGEX ]]; then
               echo "##vso[task.setvariable variable=npm_tag]dev"
             else
               # we should never get here

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,9 +2,14 @@ variables:
   NODE_JS_VERSION: 10.15.0
 
 trigger:
-- master
-- sneakpeak
-- azure/*
+  branches:
+    include:
+      - master
+      - sneakpeak
+      - azure/*
+  tags:
+    include:
+      - v*
 
 jobs:
   - job: test_ui

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,15 +155,13 @@ jobs:
           command: logout
           containerRegistryType: Container Registry
           dockerRegistryEndpoint: dockerhub-augurproject
-      - task: npmAuthenticate@0
-        inputs:
-          customEndpoint: npmjs-augur-integration
       - task: Npm@1
         inputs:
           command: 'custom' # Options: install, publish, custom
           verbose: true
           customCommand: publish --tag $(npm_tag)
-          publishEndpoint: npmjs-augur-integration
+          customRegistry: 'useNpmrc'
+          customEndpoint: npmjs-augur-integration
     condition: |
       and
       (

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,3 +108,57 @@ jobs:
           eq(variables['Build.SourceBranch'], 'refs/heads/sneakpeak')
       )
 
+  - job: tag_build
+    displayName: build tag
+    dependsOn:
+      - test_ui
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.x'
+      - task: NodeTool@0
+        inputs:
+          versionSpec: $(NODE_JS_VERSION)
+      - task: Docker@1
+        displayName: docker login
+        inputs:
+          command: login
+          containerRegistryType: Container Registry
+          dockerRegistryEndpoint: dockerhub-augurproject
+      - bash: |
+          set -euo pipefail
+          current_tag=$(git describe --exact-match --tags)
+          if [[ -n $current_tag ]]; then
+            echo "${current_tag}"
+            LATEST_VERSION_REGEX="^[vV]?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+            DEV_VERSION_REGEX="^[vV]?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+            if [[ $current_tag =~ $LATEST_VERSION_REGEX ]]; then
+              echo "##vso[task.setvariable variable=npm_tag]latest"
+              npm run docker:release -- release
+            elsif [[ $current_tag =~ $DEV_VERSION_REGEX ]]; then
+              echo "##vso[task.setvariable variable=npm_tag]dev"
+            else
+              # we should never get here
+              echo "tag ${current_tag} doesn't match semver"
+              echo "##vso[task.setvariable variable=npm_tag]random"
+            fi
+          fi
+        displayName: set npm tag
+      - task: Docker@1
+        displayName: docker logout
+        inputs:
+          command: logout
+          containerRegistryType: Container Registry
+          dockerRegistryEndpoint: dockerhub-augurproject
+      - task: Npm@1
+        inputs:
+          command: 'custom' # Options: install, publish, custom
+          verbose: true
+          customCommand: publish --tag $(npm_tag)
+          publishEndpoint: npmjs-augur-integration
+    condition: |
+      and
+      (
+          succeeded(),
+          startsWith(variables['build.sourceBranch'], 'refs/tags/v')
+      )


### PR DESCRIPTION
In the even that a tag is pushed, azure pipelines should

* publish to npm registry
* if the tag is not a dev tag, then push a release docker image with
  both the release tag and the version