### PR TITLE
Condense get market history call

### DIFF
--- a/src/modules/events/actions/log-handlers.js
+++ b/src/modules/events/actions/log-handlers.js
@@ -175,7 +175,7 @@ export const handleOrderFilledLog = log => (dispatch, getState) => {
       )
     );
     dispatch(updateOrder(log, false));
-    dispatch(loadUserMarketTradingHistory());
+    dispatch(loadUserMarketTradingHistory({ marketId: log.marketId }));
     handlePendingOrder(log, dispatch, getState);
     handleAlertUpdate(log, dispatch, getState);
   }

--- a/src/modules/markets/reducers/market-trading-history.js
+++ b/src/modules/markets/reducers/market-trading-history.js
@@ -1,4 +1,7 @@
-import { UPDATE_MARKET_TRADING_HISTORY } from "modules/markets/actions/market-trading-history-management";
+import {
+  BULK_MARKET_TRADING_HISTORY,
+  UPDATE_MARKET_TRADING_HISTORY
+} from "modules/markets/actions/market-trading-history-management";
 import { RESET_STATE } from "modules/app/actions/reset-state";
 
 const DEFAULT_STATE = {};
@@ -9,6 +12,11 @@ export default function(tradingHistory = DEFAULT_STATE, action) {
       return {
         ...tradingHistory,
         [action.data.marketId]: action.data.marketTradingHistory
+      };
+    case BULK_MARKET_TRADING_HISTORY:
+      return {
+        ...tradingHistory,
+        ...action.data.keyedMarketTradingHistory
       };
     case RESET_STATE:
       return DEFAULT_STATE;

--- a/src/modules/pending-queue/actions/pending-queue-management.js
+++ b/src/modules/pending-queue/actions/pending-queue-management.js
@@ -20,7 +20,3 @@ export const removePendingData = (pendingId, queueName) => ({
   type: REMOVE_PENDING_DATA,
   data: { pendingId, queueName }
 });
-
-// export const clearPendingOrders = () => (dispatch, getState) => {
-//   const { blockchain, pendingOrders } = getState();
-// };

--- a/src/utils/key-by.js
+++ b/src/utils/key-by.js
@@ -1,0 +1,7 @@
+export const keyBy = (array, key) =>
+  (array || []).reduce((r, x) => ({ ...r, [key ? x[key] : x]: x }), {});
+
+export const keyArrayBy = (array, key) =>
+  (array || [])
+    .reduce((p, x) => [...p, x[key]], [])
+    .reduce((p, k) => ({ ...p, [k]: array.filter(a => a[key] === k) }), {});


### PR DESCRIPTION
another https://github.com/AugurProject/augur/issues/1284

needs augur-node master, there's a recent change to augur-node. 

condenses all the get market trading histories for all the user traded markets when user first logs in. 