### PR TITLE
design updates - market header

### DIFF
--- a/src/modules/common-elements/labels.styles.less
+++ b/src/modules/common-elements/labels.styles.less
@@ -66,8 +66,14 @@
 
     > label {
       display: inline-block;
+      height: @size-12;
       margin: 0 0 0 @size-4;
       width: @size-12;
+
+      @media @breakpoint-mobile {
+        height: @size-16;
+        width: @size-16;
+      }
 
       > svg {
         fill: none;

--- a/src/modules/common-elements/progress.styles.less
+++ b/src/modules/common-elements/progress.styles.less
@@ -84,7 +84,7 @@
   }
 
   > span:last-of-type {
-    background: @color-neutral;
+    background: @color-shadow-text;
     height: 1px;
     position: relative;
     top: 0;

--- a/src/modules/common-elements/selection.styles.less
+++ b/src/modules/common-elements/selection.styles.less
@@ -467,7 +467,7 @@
   position: relative;
 
   > button > svg {
-    fill: @color-secondary-text;
+    fill: @color-shadow-text;
     height: @size-16;
     margin-top: 0.1875rem;
     width: @size-10;
@@ -475,6 +475,19 @@
     @media @breakpoint-mobile {
       transform: scale(1.3);
     }
+  }
+
+  > button:hover,
+  > button:active {
+    > svg {
+      fill: @color-secondary-text;
+    }
+  }
+}
+
+.DotSelection_Menu-open {
+  > button > svg {
+    fill: @color-secondary-text;
   }
 }
 

--- a/src/modules/common-elements/selection.tsx
+++ b/src/modules/common-elements/selection.tsx
@@ -330,7 +330,11 @@ export class DotSelection extends React.Component<
 
   render() {
     return (
-      <div className={Styles.DotSelection_Menu}>
+      <div
+        className={classNames(Styles.DotSelection_Menu, {
+          [Styles["DotSelection_Menu-open"]]: this.state.toggleMenu
+        })}
+      >
         <button
           ref={menuIcon => {
             this.refMenuIcon = menuIcon;

--- a/src/modules/common/components/markdown-renderer/markdown-renderer.styles.less
+++ b/src/modules/common/components/markdown-renderer/markdown-renderer.styles.less
@@ -4,6 +4,10 @@
   white-space: pre-wrap;
 }
 
+.MarkdownRenderer p {
+  line-height: 140%;
+}
+
 .MarkdownRenderer ul {
   display: block;
   list-style-type: disc;

--- a/src/modules/market/components/market-header/market-header.jsx
+++ b/src/modules/market/components/market-header/market-header.jsx
@@ -30,7 +30,8 @@ import { MarketTimeline } from "modules/common-elements/progress";
 
 import ToggleHeightStyles from "utils/toggle-height/toggle-height.styles";
 
-const OVERFLOW_DETAILS_LENGTH = 89; // in px, matches additional details label max-height
+const MAX_DETAILS_LENGTH = 500; // Show MORE for details when greater than 500 char length
+
 export default class MarketHeader extends Component {
   static propTypes = {
     description: PropTypes.string.isRequired,
@@ -64,36 +65,16 @@ export default class MarketHeader extends Component {
     super(props);
     this.state = {
       showReadMore: false,
-      detailsHeight: 0,
       headerCollapsed: false
     };
 
     this.gotoFilter = this.gotoFilter.bind(this);
     this.toggleReadMore = this.toggleReadMore.bind(this);
-    this.updateDetailsHeight = this.updateDetailsHeight.bind(this);
     this.toggleMarketHeader = this.toggleMarketHeader.bind(this);
     this.addToFavorites = this.addToFavorites.bind(this);
   }
 
-  componentDidMount() {
-    this.updateDetailsHeight();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props !== prevProps) this.updateDetailsHeight();
-  }
-
-  updateDetailsHeight() {
-    if (this.detailsContainer)
-      this.setState({
-        detailsHeight: this.detailsContainer.scrollHeight
-      });
-  }
-
   toggleReadMore() {
-    if (this.state.showReadMore && this.detailsContainer) {
-      this.detailsContainer.scrollTop = 0;
-    }
     this.setState({ showReadMore: !this.state.showReadMore });
   }
 
@@ -192,7 +173,8 @@ export default class MarketHeader extends Component {
     } = this.props;
     let { details } = this.props;
     const { headerCollapsed } = this.state;
-    const detailsTooLong = this.state.detailsHeight > OVERFLOW_DETAILS_LENGTH;
+    const detailsTooLong =
+      market.details && market.details.length > MAX_DETAILS_LENGTH;
 
     if (marketType === SCALAR) {
       const denomination = scalarDenomination ? ` ${scalarDenomination}` : "";
@@ -300,14 +282,17 @@ export default class MarketHeader extends Component {
                         {
                           [Styles["MarketHeader__AdditionalDetails-tall"]]:
                             detailsTooLong && this.state.showReadMore
-                        },
-                        {
-                          [Styles["MarketHeader__AdditionalDetails-fade"]]:
-                            detailsTooLong && !this.state.showReadMore
                         }
                       )}
                     >
-                      <MarkdownRenderer text={details} hideLabel />
+                      <MarkdownRenderer
+                        text={
+                          this.state.showReadMore
+                            ? details
+                            : `${details.substr(0, MAX_DETAILS_LENGTH)}...`
+                        }
+                        hideLabel
+                      />
                     </label>
 
                     {detailsTooLong && (
@@ -325,7 +310,7 @@ export default class MarketHeader extends Component {
                           ? ChevronDown({ stroke: "#FFFFFF" })
                           : ChevronUp()}
                         <span>
-                          {!this.state.showReadMore ? "More..." : "Less"}
+                          {!this.state.showReadMore ? "More" : "Less"}
                         </span>
                       </button>
                     )}
@@ -373,7 +358,12 @@ export default class MarketHeader extends Component {
               this.toggleMarketHeader(currentAugurTimestamp, market)
             }
           >
-            <ChevronFlip quick pointDown={headerCollapsed} stroke="white" />
+            <ChevronFlip
+              stroke="#999999"
+              quick
+              filledInIcon
+              pointDown={!headerCollapsed}
+            />
           </button>
         </div>
       </section>

--- a/src/modules/market/components/market-header/market-header.jsx
+++ b/src/modules/market/components/market-header/market-header.jsx
@@ -80,11 +80,11 @@ export default class MarketHeader extends Component {
     this.updateDetailsHeight();
   }
 
-   componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps) {
     if (this.props !== prevProps) this.updateDetailsHeight();
   }
 
-   updateDetailsHeight() {
+  updateDetailsHeight() {
     if (this.detailsContainer) {
       this.setState({
         detailsHeight: this.detailsContainer.scrollHeight
@@ -192,7 +192,7 @@ export default class MarketHeader extends Component {
     let { details } = this.props;
     const { headerCollapsed } = this.state;
     const detailsTooLong =
-      market.details && market.details.length > OVERFLOW_DETAILS_LENGTH;
+      market.details && this.state.detailsHeight > OVERFLOW_DETAILS_LENGTH;
 
     if (marketType === SCALAR) {
       const denomination = scalarDenomination ? ` ${scalarDenomination}` : "";
@@ -303,10 +303,7 @@ export default class MarketHeader extends Component {
                         }
                       )}
                     >
-                      <MarkdownRenderer
-                        text={details}
-                        hideLabel
-                      />
+                      <MarkdownRenderer text={details} hideLabel />
                     </label>
 
                     {detailsTooLong && (

--- a/src/modules/market/components/market-header/market-header.jsx
+++ b/src/modules/market/components/market-header/market-header.jsx
@@ -30,7 +30,7 @@ import { MarketTimeline } from "modules/common-elements/progress";
 
 import ToggleHeightStyles from "utils/toggle-height/toggle-height.styles";
 
-const MAX_DETAILS_LENGTH = 500; // Show MORE for details when greater than 500 char length
+const OVERFLOW_DETAILS_LENGTH = 89; // in px, overflow limit to trigger MORE details
 
 export default class MarketHeader extends Component {
   static propTypes = {
@@ -65,13 +65,31 @@ export default class MarketHeader extends Component {
     super(props);
     this.state = {
       showReadMore: false,
+      detailsHeight: 0,
       headerCollapsed: false
     };
 
     this.gotoFilter = this.gotoFilter.bind(this);
     this.toggleReadMore = this.toggleReadMore.bind(this);
+    this.updateDetailsHeight = this.updateDetailsHeight.bind(this);
     this.toggleMarketHeader = this.toggleMarketHeader.bind(this);
     this.addToFavorites = this.addToFavorites.bind(this);
+  }
+
+  componentDidMount() {
+    this.updateDetailsHeight();
+  }
+
+   componentDidUpdate(prevProps) {
+    if (this.props !== prevProps) this.updateDetailsHeight();
+  }
+
+   updateDetailsHeight() {
+    if (this.detailsContainer) {
+      this.setState({
+        detailsHeight: this.detailsContainer.scrollHeight
+      });
+    }
   }
 
   toggleReadMore() {
@@ -174,7 +192,7 @@ export default class MarketHeader extends Component {
     let { details } = this.props;
     const { headerCollapsed } = this.state;
     const detailsTooLong =
-      market.details && market.details.length > MAX_DETAILS_LENGTH;
+      market.details && market.details.length > OVERFLOW_DETAILS_LENGTH;
 
     if (marketType === SCALAR) {
       const denomination = scalarDenomination ? ` ${scalarDenomination}` : "";
@@ -286,11 +304,7 @@ export default class MarketHeader extends Component {
                       )}
                     >
                       <MarkdownRenderer
-                        text={
-                          this.state.showReadMore
-                            ? details
-                            : `${details.substr(0, MAX_DETAILS_LENGTH)}...`
-                        }
+                        text={details}
                         hideLabel
                       />
                     </label>

--- a/src/modules/market/components/market-header/market-header.styles.less
+++ b/src/modules/market/components/market-header/market-header.styles.less
@@ -56,7 +56,7 @@
   padding: 0 0 @size-8 0;
   resize: none;
   text-transform: none;
-  transition: max-height 100ms ease-out;
+  transition: max-height 0.15s ease-out;
   white-space: pre-wrap;
 
   > p {
@@ -67,6 +67,7 @@
 .MarketHeader__AdditionalDetails-tall {
   max-height: 1000px;
   overflow-y: auto;
+  transition: max-height 0.15s ease-in;
 }
 
 .MarketHeader__backButton {
@@ -154,6 +155,7 @@
   color: @color-secondary-text;
   cursor: pointer;
   margin-top: @size-12;
+  text-transform: uppercase;
 
   svg {
     height: 1em;
@@ -288,7 +290,7 @@
     }
 
     > div:nth-of-type(3) {
-      margin-top: @size-16;
+      padding-top: 1px;
     }
   }
 

--- a/src/modules/market/components/market-header/market-header.styles.less
+++ b/src/modules/market/components/market-header/market-header.styles.less
@@ -51,7 +51,7 @@
   border: 0;
   margin: 0;
   margin-top: -10px;
-  max-height: 95px;
+  max-height: 90px;
   overflow: hidden;
   padding: 0 0 @size-8 0;
   resize: none;

--- a/src/modules/market/components/market-header/market-header.styles.less
+++ b/src/modules/market/components/market-header/market-header.styles.less
@@ -51,7 +51,7 @@
   border: 0;
   margin: 0;
   margin-top: -10px;
-  max-height: 89px;
+  max-height: 95px;
   overflow: hidden;
   padding: 0 0 @size-8 0;
   resize: none;


### PR DESCRIPTION


https://github.com/AugurProject/augur/issues/1535

> Looks good. There are few things that still need addressing. Nothing major but would be good to get these in.
> 
> * [x]  update this arrow to the arrow we're using across the designs
>   ![image.png](https://camo.githubusercontent.com/132f3f75c67a64823781f6c58c1783cefebd9695/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563303761663437303335383935333038393131633463352f62396433336362372d373538392d343163662d396232302d376234373763343134333335)
> * [x]  Nudge up roughly 2px the Estimated fee figure - so it lines up with 24hr volume figure
>   ![image.png](https://camo.githubusercontent.com/cc2540c16f15c0dd86e7e33ff18c28e33a708ed0/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563303761663437303335383935333038393131633463352f36643564316434392d356236612d343337312d386333352d653734663535613239643065)
> * [x]  Can we add some line height to the additional details copy. I have 140% in the figma file. This should be standard for 12px Roboto paragraph text. Lets it breathe and is easier to read
>   ![image.png](https://camo.githubusercontent.com/9a4a9e65a1648adee7adddbc55f6f33c34bb4449/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563303761663437303335383935333038393131633463352f31656538636463652d663065332d346339352d613661362d646566353639313636623331)
> * [x]   update 'More' button - see design
> * [x]  hidden text should end with ellipses and shouldn't cut through a line of text. This is what I'm seeing on the build. Is it possible for it to work like the screenshot above?
>   ![image.png](https://camo.githubusercontent.com/68ed1c7f35d9cf7606ba92bf023ee5f2fec0ecf4/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563303761663437303335383935333038393131633463352f36663261643336352d366532322d343434392d396537392d656661663765363139346165)
> * [x]  animation to show less/more could be smoothed out. When I click 'less' it pushes the content below down before pulling it back up. Should be a smooth eased transition with no jerkiness.
> * [x]  default state for menu button should be #76737E. White on hover/active
>   ![image.png](https://camo.githubusercontent.com/8232b5450e9346aa8d2e6c8f08fccd2bb3847ae5/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563303761663437303335383935333038393131633463352f31316166646139652d366134662d343334622d626462312d373961643837636366623338)
> * [x]  change timeframe line background colour to #76737E
>   ![image.png](https://camo.githubusercontent.com/70ce9228702c093816128afa8029df31d9b1b6d6/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563303761663437303335383935333038393131633463352f39353763653366302d336136362d346163642d383636652d356433653363633865316433)

