### PR TITLE
fixed height and jumping

### DIFF
--- a/src/modules/portfolio/components/common/headers/data-table-header.styles.less
+++ b/src/modules/portfolio/components/common/headers/data-table-header.styles.less
@@ -4,6 +4,7 @@
   display: grid;
   flex-direction: row;
   grid-template-columns: repeat(5, 1fr);
+  min-height: 2rem;
   padding: 0.75rem 2.8rem 0.75rem 0;
   width: 100%;
 
@@ -59,7 +60,7 @@
   grid-template-columns: repeat(6, 1fr);
   padding-bottom: 0.75rem;
   padding-right: 1.75rem;
-  padding-top: 0.75rem;
+  padding-top: 0.85rem;
 }
 
 .FilledOrdersHeader__extended {


### PR DESCRIPTION
Fixed height for mobile open orders header to min be 2rem. 
Extra, fixed order form jumping when user toggles between filled orders and positions on trading page


https://github.com/AugurProject/augur/issues/1743


![Screen Shot 2019-04-22 at 11 03 25 AM](https://user-images.githubusercontent.com/3970376/56510070-5b674780-64ee-11e9-9371-8de575f32a81.png)


