### PR TITLE
fixed filled orders not showing up in portfolio

### DIFF
--- a/src/modules/markets/selectors/market.js
+++ b/src/modules/markets/selectors/market.js
@@ -341,7 +341,7 @@ const assembleMarket = (
 
       market.filledOrders = selectFilledOrders(
         marketPriceHistory,
-        (accountAddress || {}).address,
+        accountAddress,
         marketOutcomesData,
         market,
         market.userOpenOrders


### PR DESCRIPTION
fixed portfolio filled orders not showing. account wasn't getting passed to filled-orders selector.