### PR TITLE
revert getSyncData every other block, add in check for negative blocks behind

### DIFF
--- a/src/modules/app/actions/sync-blockchain.js
+++ b/src/modules/app/actions/sync-blockchain.js
@@ -38,18 +38,16 @@ export const syncBlockchain = cb => (dispatch, getState) => {
     cb && cb();
   });
 
-  if (blockNumber % 2 === 0) {
-    augur.augurNode.getSyncData((err, res) => {
-      if (!err && res) {
-        dispatch(
-          updateBlockchain({
-            highestBlock: res.highestBlock.number,
-            lastProcessedBlock: res.lastProcessedBlock.number
-          })
-        );
-      }
-    });
-  }
+  augur.augurNode.getSyncData((err, res) => {
+    if (!err && res) {
+      dispatch(
+        updateBlockchain({
+          highestBlock: res.highestBlock.number,
+          lastProcessedBlock: res.lastProcessedBlock.number
+        })
+      );
+    }
+  });
 
   dispatch(updateAssets());
 };

--- a/src/modules/block-info/selectors/block-info-data.ts
+++ b/src/modules/block-info/selectors/block-info-data.ts
@@ -19,7 +19,8 @@ export const selectBlockInfoData = createSelector(
       const lastProcessedBlockBn = createBigNumber(lastProcessedBlock);
 
       const diff = highestBlockBn.minus(lastProcessedBlockBn);
-      let blocksBehind = formatNumber(diff.toString()).roundedFormatted;
+      const diffBlocks = diff.lt(ZERO) ? ZERO : diff;
+      let blocksBehind = formatNumber(diffBlocks.toString()).roundedFormatted;
 
       blocksBehind = blocksBehind === "-" ? 0 : blocksBehind;
 


### PR DESCRIPTION
get sync data from augur-node each block, don't show negative blocks behind show zero.
it's possible that current block to be behind augur-node's processed block so blocks behind would show up negative.

https://github.com/AugurProject/augur/issues/1907