### PR TITLE
extra-long-outcome-tooltip

### DIFF
--- a/src/modules/portfolio/components/common/rows/filled-order.tsx
+++ b/src/modules/portfolio/components/common/rows/filled-order.tsx
@@ -4,7 +4,11 @@ import classNames from "classnames";
 import getValue from "utils/get-value";
 
 import { formatEther, formatShares } from "utils/format-number";
-import { PositionTypeLabel, ValueLabel } from "modules/common-elements/labels";
+import {
+  PositionTypeLabel,
+  ValueLabel,
+  TextLabel
+} from "modules/common-elements/labels";
 
 import ToggleRow from "modules/portfolio/components/common/rows/toggle-row";
 import { FilledOrderInterface } from "modules/portfolio/types";
@@ -53,7 +57,12 @@ const FilledOrder = (props: FilledOrderProps) => {
               [Styles.FilledOrder__extendedView]: extendedView
             })}
           >
-            <li>{filledOrder.outcome}</li>
+            <li>
+              <TextLabel
+                text={filledOrder.outcome}
+                keyId={`${originalQuantity}-${orderQuantity}-${orderPrice}`}
+              />
+            </li>
             <li>
               <PositionTypeLabel type={orderType} pastTense />
             </li>

--- a/src/modules/portfolio/components/common/rows/open-order.tsx
+++ b/src/modules/portfolio/components/common/rows/open-order.tsx
@@ -5,7 +5,8 @@ import {
   LinearPropertyLabel,
   PendingLabel,
   PositionTypeLabel,
-  ValueLabel
+  ValueLabel,
+  TextLabel
 } from "modules/common-elements/labels";
 import ToggleRow from "modules/portfolio/components/common/rows/toggle-row";
 import { Order } from "modules/portfolio/types";
@@ -33,6 +34,8 @@ const OpenOrder = (props: OpenOrderProps) => {
   const creationTime = getValue(openOrder, "creationTime.formattedShort");
   const avgPrice = getValue(openOrder, "avgPrice");
   const unmatchedShares = getValue(openOrder, "unmatchedShares");
+  const orderLabel =
+    openOrder.description || openOrder.name || openOrder.outcomeName;
 
   const rowContent = (
     <ul
@@ -42,7 +45,7 @@ const OpenOrder = (props: OpenOrderProps) => {
       })}
     >
       <li>
-        {openOrder.description || openOrder.name || openOrder.outcomeName}
+        <TextLabel text={orderLabel} keyId={openOrder.id} />
       </li>
       <li>
         <PositionTypeLabel type={openOrder.type} />

--- a/src/modules/portfolio/components/common/rows/position-row.tsx
+++ b/src/modules/portfolio/components/common/rows/position-row.tsx
@@ -6,7 +6,8 @@ import {
   LinearPropertyLabelMovement,
   PositionTypeLabel,
   MovementLabel,
-  ValueLabel
+  ValueLabel,
+  TextLabel
 } from "modules/common-elements/labels";
 import ToggleRow from "modules/portfolio/components/common/rows/toggle-row";
 import { Order } from "modules/portfolio/types";
@@ -67,7 +68,9 @@ const PositionRow = (props: PositionRowProps) => {
         [Styles.Position__extended]: extendedView
       })}
     >
-      <li>{position.outcomeName}</li>
+      <li>
+        <TextLabel text={position.outcomeName} keyId={position.totalCost} />
+      </li>
       <li>
         <PositionTypeLabel type={position.type} />
       </li>


### PR DESCRIPTION
added outcome name tooltips to areas that were missing in the event of an extra long outcome name

https://github.com/AugurProject/augur/issues/1396