### PR TITLE
Fix fill order lag

### DIFF
--- a/src/modules/auth/actions/load-account-history.js
+++ b/src/modules/auth/actions/load-account-history.js
@@ -9,6 +9,8 @@ import {
 import { loadUserMarketTradingHistory } from "modules/markets/actions/market-trading-history-management";
 import { clearTransactions } from "modules/transactions/actions/update-transactions-data";
 import { loadAlerts } from "modules/alerts/actions/alerts";
+import { loadUsershareBalances } from "modules/positions/actions/load-user-share-balances";
+import { getWinningBalance } from "modules/reports/actions/get-winning-balance";
 import { loadMarketsInfoIfNotLoaded } from "modules/markets/actions/load-markets-info";
 
 export const loadAccountHistory = () => (dispatch, getState) => {
@@ -50,6 +52,8 @@ function loadTransactions(dispatch, callback) {
       new Set(marketIds.reduce((p, mids) => p.concat(mids), []))
     );
 
+    dispatch(loadUsershareBalances(uniqMarketIds));
+    dispatch(getWinningBalance(uniqMarketIds));
     dispatch(loadMarketsInfoIfNotLoaded(uniqMarketIds), () => {
       callback();
     });

--- a/src/modules/auth/actions/load-account-history.js
+++ b/src/modules/auth/actions/load-account-history.js
@@ -24,8 +24,12 @@ export const loadAccountHistory = () => (dispatch, getState) => {
 
 function loadTransactions(dispatch, callback) {
   const options = {};
-  dispatch(loadUserMarketTradingHistory(options));
   const promises = [];
+  promises.push(
+    new Promise(resolve =>
+      dispatch(loadUserMarketTradingHistory(options, null, resolve))
+    )
+  );
   promises.push(
     new Promise(resolve =>
       dispatch(loadAccountPositions(options, null, resolve))
@@ -49,7 +53,12 @@ function loadTransactions(dispatch, callback) {
 
   Promise.all(promises).then(marketIds => {
     const uniqMarketIds = Array.from(
-      new Set(marketIds.reduce((p, mids) => p.concat(mids), []))
+      new Set(
+        marketIds.reduce(
+          (p, mids) => p.concat(mids.filter(m => m !== null)),
+          []
+        )
+      )
     );
 
     dispatch(loadUsershareBalances(uniqMarketIds));

--- a/src/modules/events/actions/log-handlers.test.js
+++ b/src/modules/events/actions/log-handlers.test.js
@@ -24,7 +24,7 @@ describe("modules/events/actions/log-handlers.js", () => {
     let loadReportingWindowBoundsSpy;
     let getWinningBalanceSpy;
     let loadMarketOpenOrdersSpy;
-    let loadAccountPositions;
+    let loadMarketAccountPositions;
     let updateAssetsSpy;
     const ACTIONS = {
       UPDATE_LOGGED_TRANSACTIONS: "UPDATE_LOGGED_TRANSACTIONS",
@@ -65,8 +65,8 @@ describe("modules/events/actions/log-handlers.js", () => {
             marketId: options.marketId
           }
         }));
-      loadAccountPositions = jest
-        .spyOn(loadAccountPositionsModule, "loadAccountPositions")
+      loadMarketAccountPositions = jest
+        .spyOn(loadAccountPositionsModule, "loadMarketAccountPositions")
         .mockImplementation(() => ({
           type: ACTIONS.LOAD_ACCOUNT_POSITIONS
         }));
@@ -84,7 +84,7 @@ describe("modules/events/actions/log-handlers.js", () => {
       loadAccountTradesSpy.mockReset();
       getWinningBalanceSpy.mockReset();
       loadMarketOpenOrdersSpy.mockReset();
-      loadAccountPositions.mockReset();
+      loadMarketAccountPositions.mockReset();
       updateAssetsSpy.mockReset();
     });
 
@@ -117,6 +117,10 @@ describe("modules/events/actions/log-handlers.js", () => {
         },
         {
           type: ACTIONS.LOAD_ACCOUNT_POSITIONS
+        },
+        {
+          type: ACTIONS.GET_WINNING_BALANCE,
+          data: { marketIds: ["0xdeadbeef"] }
         }
       ]);
     });
@@ -212,6 +216,10 @@ describe("modules/events/actions/log-handlers.js", () => {
         },
         {
           type: ACTIONS.LOAD_ACCOUNT_POSITIONS
+        },
+        {
+          type: ACTIONS.GET_WINNING_BALANCE,
+          data: { marketIds: ["0xdeadbeef"] }
         }
       ]);
     });

--- a/src/modules/markets/actions/market-trading-history-management.js
+++ b/src/modules/markets/actions/market-trading-history-management.js
@@ -66,7 +66,23 @@ export const loadMarketTradingHistory = (options, callback = logError) => (
   });
 };
 
-export const loadUserMarketTradingHistory = (options, callback = logError) => (
+export const loadUserMarketTradingHistory = (
+  options = {},
+  callback = logError,
+  marketIdAggregator
+) => (dispatch, getState) => {
+  dispatch(
+    loadUserMarketTradingHistoryInternal(
+      options,
+      (err, { marketIds = [], tradingHistory = {} }) => {
+        if (marketIdAggregator && marketIdAggregator(marketIds));
+        if (callback) callback(err, tradingHistory);
+      }
+    )
+  );
+};
+
+export const loadUserMarketTradingHistoryInternal = (options, callback) => (
   dispatch,
   getState
 ) => {
@@ -77,8 +93,8 @@ export const loadUserMarketTradingHistory = (options, callback = logError) => (
     options
   );
   getTradingHistory(allOptions, (err, tradingHistory) => {
-    if (err) return callback(err);
-    if (tradingHistory == null) return callback(null, []);
+    if (err) return callback(err, {});
+    if (tradingHistory == null) return callback(null, {});
     if (!allOptions.marketId) {
       dispatch(
         loadReportingFinal((err, finalizedMarkets) => {
@@ -103,6 +119,7 @@ export const loadUserMarketTradingHistory = (options, callback = logError) => (
                 if (!err) {
                   dispatch(bulkMarketTradingHistory(keyedMarketTradeHistory));
                 }
+                callback(null, { tradingHistory, marketIds });
               }
             );
           }
@@ -120,9 +137,8 @@ export const loadUserMarketTradingHistory = (options, callback = logError) => (
       );
     } else {
       dispatch(updateUserTradingHistory(loginAccount.address, tradingHistory));
+      callback(err, tradingHistory);
     }
-
-    callback(null, tradingHistory);
   });
 };
 

--- a/src/modules/markets/selectors/market.js
+++ b/src/modules/markets/selectors/market.js
@@ -323,8 +323,8 @@ const assembleMarket = (
     name: INDETERMINATE_OUTCOME_NAME
   });
 
+  market.myPositionsSummary = {};
   if (userTradingPositions.tradingPositionsPerMarket) {
-    market.myPositionsSummary = {};
     const marketPositions = userTradingPositions.tradingPositionsPerMarket;
     // leave complete sets here, until we finish new notifications
     if (numCompleteSets) {

--- a/src/modules/orders/actions/load-account-open-orders.js
+++ b/src/modules/orders/actions/load-account-open-orders.js
@@ -45,7 +45,7 @@ const loadUserAccountOrders = (options = {}, callback) => (
 
 const postProcessing = (marketIds, dispatch, orders, callback) => {
   marketIds.forEach(marketId =>
-    shapeGetOrders(orders, marketId).map(v => dispatch(updateOrderBook(v)))
+    dispatch(updateOrderBook(shapeGetOrders(orders, marketId)))
   );
 
   if (callback) callback(null, orders);

--- a/src/modules/orders/actions/load-market-open-orders.js
+++ b/src/modules/orders/actions/load-market-open-orders.js
@@ -20,9 +20,7 @@ export const loadMarketOpenOrders = (marketId, callback = logError) => (
     },
     (err, orders) => {
       if (err) return callback(err);
-      if (orders != null) {
-        shapeGetOrders(orders, marketId).map(v => dispatch(updateOrderBook(v)));
-      }
+      dispatch(updateOrderBook(shapeGetOrders(orders, marketId)));
       callback(null);
     }
   );

--- a/src/modules/orders/actions/update-order-book.js
+++ b/src/modules/orders/actions/update-order-book.js
@@ -17,25 +17,3 @@ export const updateOrderBook = ({
     orderBook
   }
 });
-export const clearOrderBook = (marketId, outcome, orderTypeLabel) => ({
-  type: CLEAR_ORDER_BOOK,
-  data: {
-    marketId,
-    outcome,
-    orderTypeLabel
-  }
-});
-export const updateIsFirstOrderBookChunkLoaded = ({
-  marketId,
-  outcome,
-  orderTypeLabel,
-  isLoaded
-}) => ({
-  type: UPDATE_IS_FIRST_ORDER_BOOK_CHUNK_LOADED,
-  data: {
-    marketId,
-    outcome,
-    orderTypeLabel,
-    isLoaded
-  }
-});

--- a/src/modules/orders/actions/update-order-book.js
+++ b/src/modules/orders/actions/update-order-book.js
@@ -1,19 +1,11 @@
 export const UPDATE_ORDER_BOOK = "UPDATE_ORDER_BOOK";
-export const CLEAR_ORDER_BOOK = "CLEAR_ORDER_BOOK";
 export const UPDATE_IS_FIRST_ORDER_BOOK_CHUNK_LOADED =
   "UPDATE_IS_FIRST_ORDER_BOOK_CHUNK_LOADED";
 
-export const updateOrderBook = ({
-  marketId,
-  outcome,
-  orderTypeLabel,
-  orderBook
-}) => ({
+export const updateOrderBook = ({ marketId, orderBook }) => ({
   type: UPDATE_ORDER_BOOK,
   data: {
     marketId,
-    outcome,
-    orderTypeLabel,
     orderBook
   }
 });

--- a/src/modules/orders/actions/update-order-book.test.js
+++ b/src/modules/orders/actions/update-order-book.test.js
@@ -6,49 +6,47 @@ import {
 describe(`modules/orders/actions/update-order-book.js`, () => {
   test(`should fire the UPDATE_ORDER_BOOK action with data`, () => {
     const marketId = "MARKET_1";
-    const outcome = 3;
-    const orderTypeLabel = "buy";
     const orderBook = {
-      "0x1": {
-        amount: "1.1111",
-        fullPrecisionAmount: "1.1111111",
-        price: "0.7778",
-        fullPrecisionPrice: "0.7777777",
-        owner: "0x0000000000000000000000000000000000000b0b",
-        tokensEscrowed: "0.8641974",
-        sharesEscrowed: "0",
-        betterOrderId:
-          "0x000000000000000000000000000000000000000000000000000000000000000a",
-        worseOrderId:
-          "0x000000000000000000000000000000000000000000000000000000000000000b",
-        gasPrice: "20000000000"
-      },
-      "0xf": {
-        amount: "1.1111",
-        fullPrecisionAmount: "1.1111111",
-        price: "0.7778",
-        fullPrecisionPrice: "0.7777777",
-        owner: "0x0000000000000000000000000000000000000b0b",
-        tokensEscrowed: "0.8641974",
-        sharesEscrowed: "0",
-        betterOrderId:
-          "0x000000000000000000000000000000000000000000000000000000000000000a",
-        worseOrderId:
-          "0x000000000000000000000000000000000000000000000000000000000000000b",
-        gasPrice: "20000000001"
+      3: {
+        buy: {
+          "0x1": {
+            amount: "1.1111",
+            fullPrecisionAmount: "1.1111111",
+            price: "0.7778",
+            fullPrecisionPrice: "0.7777777",
+            owner: "0x0000000000000000000000000000000000000b0b",
+            tokensEscrowed: "0.8641974",
+            sharesEscrowed: "0",
+            betterOrderId:
+              "0x000000000000000000000000000000000000000000000000000000000000000a",
+            worseOrderId:
+              "0x000000000000000000000000000000000000000000000000000000000000000b",
+            gasPrice: "20000000000"
+          },
+          "0xf": {
+            amount: "1.1111",
+            fullPrecisionAmount: "1.1111111",
+            price: "0.7778",
+            fullPrecisionPrice: "0.7777777",
+            owner: "0x0000000000000000000000000000000000000b0b",
+            tokensEscrowed: "0.8641974",
+            sharesEscrowed: "0",
+            betterOrderId:
+              "0x000000000000000000000000000000000000000000000000000000000000000a",
+            worseOrderId:
+              "0x000000000000000000000000000000000000000000000000000000000000000b",
+            gasPrice: "20000000001"
+          }
+        }
       }
     };
     const expectedOutput = {
       type: UPDATE_ORDER_BOOK,
       data: {
         marketId,
-        outcome,
-        orderTypeLabel,
         orderBook
       }
     };
-    expect(
-      updateOrderBook({ marketId, outcome, orderTypeLabel, orderBook })
-    ).toEqual(expectedOutput);
+    expect(updateOrderBook({ marketId, orderBook })).toEqual(expectedOutput);
   });
 });

--- a/src/modules/orders/helpers/shape-getOrders.js
+++ b/src/modules/orders/helpers/shape-getOrders.js
@@ -1,6 +1,6 @@
 export const shapeGetOrders = (orders, marketId, orderState) => {
-  const processedOrders = [];
-  if (Object.keys(orders).length === 0) return processedOrders;
+  const marketOrders = {};
+  if (Object.keys(orders).length === 0) return { marketId, orderBook: {} };
   Object.keys(orders[marketId]).forEach(outcome => {
     Object.keys(orders[marketId][outcome]).forEach(orderTypeLabel => {
       const orderBook = orders[marketId][outcome][orderTypeLabel];
@@ -12,13 +12,12 @@ export const shapeGetOrders = (orders, marketId, orderState) => {
             return p;
           }, {})
         : orderBook;
-      processedOrders.push({
-        marketId,
-        outcome,
-        orderTypeLabel,
-        orderBook: filteredOrders
-      });
+
+      marketOrders[outcome] = {
+        ...marketOrders[outcome],
+        [orderTypeLabel]: filteredOrders
+      };
     });
   });
-  return processedOrders;
+  return { marketId, orderBook: marketOrders };
 };

--- a/src/modules/orders/reducers/order-books.js
+++ b/src/modules/orders/reducers/order-books.js
@@ -9,20 +9,14 @@ const DEFAULT_STATE = {};
 export default function(orderBooks = DEFAULT_STATE, { type, data }) {
   switch (type) {
     case UPDATE_ORDER_BOOK: {
-      const { marketId, outcome, orderTypeLabel, orderBook } = data;
-      const marketOrderBook = orderBooks[marketId] || {};
-      const outcomeOrderBook = marketOrderBook[outcome] || {};
+      const { marketId, orderBook } = data;
+      const newOrderBooks = Object.keys(orderBooks).reduce(
+        (p, m) => (m !== marketId ? { ...p, [m]: orderBooks[m] } : p),
+        {}
+      );
       return {
-        ...orderBooks,
-        [marketId]: {
-          ...marketOrderBook,
-          [outcome]: {
-            ...outcomeOrderBook,
-            [orderTypeLabel]: {
-              ...orderBook
-            }
-          }
-        }
+        ...newOrderBooks,
+        [marketId]: orderBook
       };
     }
     case RESET_STATE:

--- a/src/modules/orders/reducers/order-books.js
+++ b/src/modules/orders/reducers/order-books.js
@@ -1,7 +1,4 @@
-import {
-  UPDATE_ORDER_BOOK,
-  CLEAR_ORDER_BOOK
-} from "modules/orders/actions/update-order-book";
+import { UPDATE_ORDER_BOOK } from "modules/orders/actions/update-order-book";
 import { RESET_STATE } from "modules/app/actions/reset-state";
 
 const DEFAULT_STATE = {};
@@ -22,24 +19,8 @@ export default function(orderBooks = DEFAULT_STATE, { type, data }) {
           [outcome]: {
             ...outcomeOrderBook,
             [orderTypeLabel]: {
-              ...(outcomeOrderBook[orderTypeLabel] || {}),
               ...orderBook
             }
-          }
-        }
-      };
-    }
-    case CLEAR_ORDER_BOOK: {
-      const { marketId, outcome, orderTypeLabel } = data;
-      const marketOrderBook = orderBooks[marketId] || {};
-      const outcomeOrderBook = marketOrderBook[outcome] || {};
-      return {
-        ...orderBooks,
-        [marketId]: {
-          ...marketOrderBook,
-          [outcome]: {
-            ...outcomeOrderBook,
-            [orderTypeLabel]: {}
           }
         }
       };

--- a/src/modules/orders/reducers/order-books.test.js
+++ b/src/modules/orders/reducers/order-books.test.js
@@ -14,30 +14,32 @@ describe(`modules/orders/reducers/order-books.js`, () => {
       type: UPDATE_ORDER_BOOK,
       data: {
         marketId: "partyRockMarket",
-        outcome: 2,
-        orderTypeLabel: "buy",
         orderBook: {
-          "0xdbd821cc394595f9c50f32c1554059ec343471b49f84a4b72c44589a25f70ff3": {
-            amount: "50",
-            block: 1125453,
-            id:
-              "0xdbd821cc394595f9c50f32c1554059ec343471b49f84a4b72c44589a25f70ff3",
-            market: "partyRockMarket",
-            outcome: "2",
-            owner: "0x7c0d52faab596c08f484e3478aebc6205f3f5d8c",
-            price: "0.35",
-            type: "buy"
-          },
-          "0x8ef900c8aad3c4f7b65a055643d54db7b9a506a542b1270047a314da931e37fb": {
-            amount: "50",
-            block: 1127471,
-            id:
-              "0x8ef900c8aad3c4f7b65a055643d54db7b9a506a542b1270047a314da931e37fb",
-            market: "partyRockMarket",
-            outcome: "1",
-            owner: "0x457435fbcd49475847f69898f933ffefc33388fc",
-            price: "0.25",
-            type: "buy"
+          2: {
+            buy: {
+              "0xdbd821cc394595f9c50f32c1554059ec343471b49f84a4b72c44589a25f70ff3": {
+                amount: "50",
+                block: 1125453,
+                id:
+                  "0xdbd821cc394595f9c50f32c1554059ec343471b49f84a4b72c44589a25f70ff3",
+                market: "partyRockMarket",
+                outcome: "2",
+                owner: "0x7c0d52faab596c08f484e3478aebc6205f3f5d8c",
+                price: "0.35",
+                type: "buy"
+              },
+              "0x8ef900c8aad3c4f7b65a055643d54db7b9a506a542b1270047a314da931e37fb": {
+                amount: "50",
+                block: 1127471,
+                id:
+                  "0x8ef900c8aad3c4f7b65a055643d54db7b9a506a542b1270047a314da931e37fb",
+                market: "partyRockMarket",
+                outcome: "1",
+                owner: "0x457435fbcd49475847f69898f933ffefc33388fc",
+                price: "0.25",
+                type: "buy"
+              }
+            }
           }
         }
       }

--- a/src/modules/orders/selectors/filled-orders.js
+++ b/src/modules/orders/selectors/filled-orders.js
@@ -176,7 +176,11 @@ export const selectUserFilledOrders = createCachedSelector(
   selectMarketsDataStateMarket,
   selectUserOpenOrders,
   (marketTradeHistory, accountId, outcomesData, marketsData, openOrders) => {
-    if (!marketTradeHistory || marketTradeHistory.length < 1) {
+    if (
+      !marketTradeHistory ||
+      marketTradeHistory.length < 1 ||
+      marketsData === undefined
+    ) {
       return [];
     }
 


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/1781

small optimization for when user get's their order filled. Broke apart getting all users positions into get all and update only specific market position.


also fixed an issue were old orders on the book stick around b/c of how were were merging order book when open orders where refreshed. 