### PR TITLE
standardize end time sort for positions and favorites and my markets

### DIFF
--- a/src/modules/common-elements/constants.ts
+++ b/src/modules/common-elements/constants.ts
@@ -686,3 +686,6 @@ export const SMALL_MOBILE = "(max-width: 900px)"; // matches @breakpoint-mobile-
 export const TABLET = "(min-width: 901px) and (max-width: 1280px)";
 export const DESKTOP = "(min-width:1281px) and (max-width: 2000px)";
 export const LARGE_DESKTOP = "(min-width: 2001px)";
+
+// Sort variables
+export const END_TIME = "endTime";

--- a/src/modules/portfolio/components/common/quads/filter-box.tsx
+++ b/src/modules/portfolio/components/common/quads/filter-box.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ReactNode } from "react";
 
 import { find } from "lodash";
-import { ALL_MARKETS } from "modules/common-elements/constants";
+import { ALL_MARKETS, END_TIME } from "modules/common-elements/constants";
 import QuadBox from "modules/portfolio/components/common/quads/quad-box";
 import { SwitchLabelsGroup } from "modules/common-elements/switch-labels-group";
 import { NameValuePair, Market, Tab} from "modules/portfolio/types";
@@ -30,6 +30,7 @@ export interface FilterBoxProps {
   renderToggleContent?: Function;
   filterLabel: String;
   sortByStyles?: Object;
+  currentAugurTimestamp: Number;
 }
 
 interface FilterBoxState {
@@ -117,8 +118,28 @@ export default class FilterBox extends React.Component<FilterBoxProps, FilterBox
 
   applySortBy = (value: string, data: Array<Market>) => {
     const valueObj = find(this.props.sortByOptions, { value: value });
+    let comp = valueObj.comp;
 
-    data = data.sort(valueObj.comp);
+    const { currentAugurTimestamp } = this.props;
+
+    if (valueObj.value === END_TIME) {
+      comp = function(marketA, marketB) {
+          if (
+            marketA.endTime.timestamp < currentAugurTimestamp &&
+            marketB.endTime.timestamp < currentAugurTimestamp
+          ) {
+            return marketB.endTime.timestamp - marketA.endTime.timestamp;
+          }
+          if (marketA.endTime.timestamp < currentAugurTimestamp) {
+            return 1;
+          }
+          if (marketB.endTime.timestamp < currentAugurTimestamp) {
+            return -1;
+          }
+          return marketA.endTime.timestamp - marketB.endTime.timestamp;
+        }
+    }
+    data = data.sort(comp);
 
     return data;
   }

--- a/src/modules/portfolio/components/favorites/favorites.jsx
+++ b/src/modules/portfolio/components/favorites/favorites.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import FilterBox from "modules/portfolio/containers/filter-box";
 import { MarketProgress } from "modules/common-elements/progress";
 import { FavoritesButton } from "modules/common-elements/buttons";
+import { END_TIME } from "modules/common-elements/constants";
 
 import Styles from "modules/portfolio/components/common/quads/quad.styles";
 
@@ -24,7 +25,7 @@ const sortByOptions = [
   },
   {
     label: "Sort by Expiring Soonest",
-    value: "endTime",
+    value: END_TIME,
     comp(marketA, marketB) {
       return marketA.endTime.timestamp - marketB.endTime.timestamp;
     }

--- a/src/modules/portfolio/components/markets/markets.jsx
+++ b/src/modules/portfolio/components/markets/markets.jsx
@@ -4,8 +4,35 @@ import PropTypes from "prop-types";
 import FilterBox from "modules/portfolio/containers/filter-box";
 import { LinearPropertyLabel } from "modules/common-elements/labels";
 import { MarketProgress } from "modules/common-elements/progress";
+import { END_TIME } from "modules/common-elements/constants";
 
 import Styles from "modules/portfolio/components/common/quads/quad.styles";
+
+const sortByOptions = [
+  {
+    label: "Sort by Expiring Soonest",
+    value: END_TIME,
+    comp(marketA, marketB) {
+      return marketA.endTime.timestamp - marketB.endTime.timestamp;
+    }
+  },
+  {
+    label: "Sort by Most Recently Traded",
+    value: "recentlyTraded",
+    comp(marketA, marketB) {
+      return (
+        marketB.recentlyTraded.timestamp - marketA.recentlyTraded.timestamp
+      );
+    }
+  },
+  {
+    label: "Sort by Creation Time",
+    value: "creationTime",
+    comp(marketA, marketB) {
+      return marketB.creationTime.timestamp - marketA.creationTime.timestamp;
+    }
+  }
+];
 
 function filterComp(input, market) {
   return market.description.toLowerCase().indexOf(input.toLowerCase()) >= 0;
@@ -48,52 +75,6 @@ class MyMarkets extends Component {
     super(props);
 
     this.renderRightContent = this.renderRightContent.bind(this);
-    this.createSortByOptions = this.createSortByOptions.bind(this);
-  }
-
-  createSortByOptions() {
-    const { currentAugurTimestamp } = this.props;
-    const sortByOptions = [
-      {
-        label: "Sort by Expiring Soonest",
-        value: "endTime",
-        comp(marketA, marketB) {
-          if (
-            marketA.endTime.timestamp < currentAugurTimestamp &&
-            marketB.endTime.timestamp < currentAugurTimestamp
-          ) {
-            return marketB.endTime.timestamp - marketA.endTime.timestamp;
-          }
-          if (marketA.endTime.timestamp < currentAugurTimestamp) {
-            return 1;
-          }
-          if (marketB.endTime.timestamp < currentAugurTimestamp) {
-            return -1;
-          }
-          return marketA.endTime.timestamp - marketB.endTime.timestamp;
-        }
-      },
-      {
-        label: "Sort by Most Recently Traded",
-        value: "recentlyTraded",
-        comp(marketA, marketB) {
-          return (
-            marketB.recentlyTraded.timestamp - marketA.recentlyTraded.timestamp
-          );
-        }
-      },
-      {
-        label: "Sort by Creation Time",
-        value: "creationTime",
-        comp(marketA, marketB) {
-          return (
-            marketB.creationTime.timestamp - marketA.creationTime.timestamp
-          );
-        }
-      }
-    ];
-
-    return sortByOptions;
   }
 
   renderRightContent(market) {
@@ -111,8 +92,6 @@ class MyMarkets extends Component {
 
   render() {
     const { myMarkets } = this.props;
-
-    const sortByOptions = this.createSortByOptions();
 
     return (
       <FilterBox

--- a/src/modules/portfolio/components/orders/filled-orders.jsx
+++ b/src/modules/portfolio/components/orders/filled-orders.jsx
@@ -9,12 +9,12 @@ import FilledOrdersHeader from "modules/portfolio/components/common/headers/fill
 const sortByOptions = [
   {
     label: "View by Most Recently Traded Market",
-    value: "creationTime",
+    value: "tradedMarket",
     comp: null
   },
   {
     label: "View by Most Recently Traded Outcome",
-    value: "endTime",
+    value: "tradedOutcome",
     comp: null
   }
 ];

--- a/src/modules/portfolio/components/orders/open-orders.jsx
+++ b/src/modules/portfolio/components/orders/open-orders.jsx
@@ -9,12 +9,12 @@ import OrderMarketRow from "modules/portfolio/components/common/rows/order-marke
 const sortByOptions = [
   {
     label: "View by Most Recently Traded Market",
-    value: "creationTime",
+    value: "tradedMarket",
     comp: null
   },
   {
     label: "View by Most Recently Traded Outcome",
-    value: "endTime",
+    value: "tradedOutcome",
     comp: null
   }
 ];

--- a/src/modules/portfolio/components/positions/positions.jsx
+++ b/src/modules/portfolio/components/positions/positions.jsx
@@ -5,6 +5,7 @@ import FilterBox from "modules/portfolio/containers/filter-box";
 import { CompactButton } from "modules/common-elements/buttons";
 import { MovementLabel } from "modules/common-elements/labels";
 import PositionsTable from "modules/market/containers/positions-table";
+import { END_TIME } from "modules/common-elements/constants";
 
 import Styles from "modules/portfolio/components/common/quads/quad.styles";
 
@@ -40,7 +41,7 @@ const sortByOptions = [
   },
   {
     label: "Sort by Expiring Soonest",
-    value: "endTime",
+    value: END_TIME,
     comp(marketA, marketB) {
       return marketA.endTime.timestamp - marketB.endTime.timestamp;
     }

--- a/src/modules/portfolio/containers/filter-box.js
+++ b/src/modules/portfolio/containers/filter-box.js
@@ -6,7 +6,9 @@ import { pick } from "lodash";
 
 import { createMarketsStateObject } from "modules/portfolio/helpers/create-markets-state-object";
 
-const mapStateToProps = state => ({});
+const mapStateToProps = state => ({
+  currentAugurTimestamp: state.blockchain.currentAugurTimestamp
+});
 
 const mapDispatchToProps = dispatch => ({});
 

--- a/src/utils/get-outcome.js
+++ b/src/utils/get-outcome.js
@@ -9,6 +9,8 @@ export const getOutcomeName = (
   outcome,
   alwaysReturnYesForBinaryMarket = true
 ) => {
+  // default to handle app loading
+  if (!market) return YES_NO_YES_OUTCOME_NAME;
   const { marketType } = market;
   // default to handle app loading
   if (!marketType) return YES_NO_YES_OUTCOME_NAME;


### PR DESCRIPTION
https://github.com/augurproject/augur/issues/1928
https://github.com/augurproject/augur/issues/1933

fix watchlist and positions sort by end time to be same as my created markets