### PR TITLE
 need to default start time for `all time` for profit and loss chart

### DIFF
--- a/src/modules/account/components/account-overview-chart/account-overview-chart.tsx
+++ b/src/modules/account/components/account-overview-chart/account-overview-chart.tsx
@@ -37,6 +37,7 @@ interface AccountOverviewChartState {
   noTrades: boolean;
 }
 
+const BEGINNING_START_TIME = 1530366577;
 export default class AccountOverviewChart extends React.Component<
   AccountOverviewChartProps,
   AccountOverviewChartState
@@ -69,7 +70,7 @@ export default class AccountOverviewChart extends React.Component<
     let startTime: number | null =
       currentAugurTimestamp - timeRangeDataConfig.periodInterval;
     if (timeRangeDataConfig.id === ALL_TIME) {
-      startTime = null;
+      startTime = BEGINNING_START_TIME;
     }
     this.props.getProfitLoss(
       universe,


### PR DESCRIPTION
need to give start time for profit and loss chart that is far enough back to get correct data from augur-node

https://github.com/AugurProject/augur/issues/1854

example from tix
![image](https://user-images.githubusercontent.com/3970376/56966829-8ae90600-6b25-11e9-931e-e6ee560f90e4.png)


fixed example
![image](https://user-images.githubusercontent.com/3970376/56966841-90465080-6b25-11e9-983c-a8ec3776d56f.png)
