### PR TITLE
check market object has id before calling selector that uses re-reselect

### DIFF
--- a/src/modules/market/containers/market-orders-positions-table.js
+++ b/src/modules/market/containers/market-orders-positions-table.js
@@ -46,7 +46,7 @@ const mapStateToProps = (state, ownProps) => {
     canClaim = timeHasPassed.toNumber() > 0;
   }
 
-  const filledOrders = selectUserFilledOrders(state, market.id);
+  const filledOrders = market.id ? selectUserFilledOrders(state, market.id) : [];
   const hasPending = Boolean(openOrders.find(order => order.pending));
 
   return {

--- a/src/modules/market/containers/market-orders-positions-table.js
+++ b/src/modules/market/containers/market-orders-positions-table.js
@@ -46,7 +46,9 @@ const mapStateToProps = (state, ownProps) => {
     canClaim = timeHasPassed.toNumber() > 0;
   }
 
-  const filledOrders = market.id ? selectUserFilledOrders(state, market.id) : [];
+  const filledOrders = market.id
+    ? selectUserFilledOrders(state, market.id)
+    : [];
   const hasPending = Boolean(openOrders.find(order => order.pending));
 
   return {

--- a/src/modules/markets/selectors/select-bucketed-price-time-series.js
+++ b/src/modules/markets/selectors/select-bucketed-price-time-series.js
@@ -28,6 +28,8 @@ function selectMarketTradingHistoryStateMarket(state, marketId) {
 }
 
 export default function(marketId) {
+  if (!marketId) return [];
+
   return bucketedPriceTimeSeries(store.getState(), marketId);
 }
 

--- a/src/modules/portfolio/selectors/select-markets-open-orders.js
+++ b/src/modules/portfolio/selectors/select-markets-open-orders.js
@@ -21,7 +21,7 @@ export const marketsOpenOrders = createSelector(selectMarkets, allMarkets => {
       {
         ...m,
         recentlyTraded: marketsPositionsRecentlyTraded[m.id] || 0,
-        filledOrders: getUserFilledOrders(m.id) || [],
+        filledOrders: m.id ? getUserFilledOrders(m.id) || [] : [],
         userOpenOrders
       }
     ];


### PR DESCRIPTION
fix warnings in UI when market objects haven't been fully populated and re-reselector selectors are called. they need not to be called, put in a few checks.


![image](https://user-images.githubusercontent.com/3970376/57102609-88cfa480-6ce9-11e9-82e5-28d77444c3a5.png)


no tix for this one