### PR TITLE
Portfolio padding flag

### DIFF
--- a/src/modules/filter-sort/components/filter-dropdowns/filter-dropdowns.jsx
+++ b/src/modules/filter-sort/components/filter-dropdowns/filter-dropdowns.jsx
@@ -114,12 +114,13 @@ export default class FilterSearch extends Component {
       updateSortOption,
       updateFilter,
       maxFee,
-      hasOrders
+      hasOrders,
+      hidePostV2Markets
     } = this.props;
 
     this.goToPageOne();
     updateSortOption(value);
-    updateFilter({ filter, sort: value, maxFee, hasOrders });
+    updateFilter({ filter, sort: value, maxFee, hasOrders, hidePostV2Markets });
   }
 
   changeFilterDropdown(value) {
@@ -128,20 +129,28 @@ export default class FilterSearch extends Component {
       updateFilterOption,
       updateFilter,
       maxFee,
-      hasOrders
+      hasOrders,
+      hidePostV2Markets
     } = this.props;
 
     this.goToPageOne();
     updateFilterOption(value);
-    updateFilter({ filter: value, sort, maxFee, hasOrders });
+    updateFilter({ filter: value, sort, maxFee, hasOrders, hidePostV2Markets });
   }
 
   changeMaxFees(maxFee) {
-    const { sort, filter, updateMaxFee, hasOrders, updateFilter } = this.props;
+    const {
+      sort,
+      filter,
+      updateMaxFee,
+      hasOrders,
+      updateFilter,
+      hidePostV2Markets
+    } = this.props;
 
     this.goToPageOne();
     updateMaxFee(maxFee);
-    updateFilter({ filter, sort, maxFee, hasOrders });
+    updateFilter({ filter, sort, maxFee, hasOrders, hidePostV2Markets });
   }
 
   changeHidePastCutoff() {

--- a/src/modules/market-charts/components/market-outcome-charts--candlestick-period-selector/market-outcome-charts--candlestick-period-selector.styles.less
+++ b/src/modules/market-charts/components/market-outcome-charts--candlestick-period-selector/market-outcome-charts--candlestick-period-selector.styles.less
@@ -2,7 +2,7 @@
 
 .PeriodSelector {
   position: relative;
-  z-index: @above-all-content;
+  z-index: 5;
 }
 
 .PeriodSelector__button {

--- a/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card.styles.less
+++ b/src/modules/portfolio/components/market-portfolio-card/market-portfolio-card.styles.less
@@ -12,6 +12,10 @@
 
 .MarketCard__headertext {
   display: inline-block !important;
+
+  > span:first-of-type > div {
+    margin-bottom: 1.25rem;
+  }
 }
 
 .MarketCard__headertext h1 {


### PR DESCRIPTION
- add padding to red flags on portfolio https://github.com/AugurProject/augur/issues/2127
- fix bug where the chart dropdown was visible when scrolling over banner
- fix bug for market list filters, where selecting a dropdown resets the market end time checkbox (this was also fixed on the wip spread PR) 