### PR TITLE
add markets at risk modal

### DIFF
--- a/src/modules/market/components/market-link/market-link.jsx
+++ b/src/modules/market/components/market-link/market-link.jsx
@@ -21,7 +21,7 @@ import {
   RETURN_PARAM_NAME
 } from "modules/routes/constants/param-names";
 
-const MarketLink = ({ linkType, className, id, children }) => {
+const MarketLink = ({ linkType, className, id, children, newTab = false }) => {
   let path;
 
   switch (linkType) {
@@ -52,6 +52,7 @@ const MarketLink = ({ linkType, className, id, children }) => {
         <Link
           data-testid={"link-" + id}
           className={className}
+          target={newTab ? "_blank" : "_self"}
           to={{
             pathname: path,
             search: makeQuery(queryLink)
@@ -70,13 +71,15 @@ MarketLink.propTypes = {
   id: PropTypes.string.isRequired,
   linkType: PropTypes.string,
   className: PropTypes.string,
-  children: PropTypes.any
+  children: PropTypes.any,
+  newTab: PropTypes.bool
 };
 
 MarketLink.defaultProps = {
   linkType: null,
   className: "",
-  children: null
+  children: null,
+  newTab: false
 };
 
 export default MarketLink;

--- a/src/modules/modal/actions/update-markets-at-risk-seen-modal.js
+++ b/src/modules/modal/actions/update-markets-at-risk-seen-modal.js
@@ -1,0 +1,6 @@
+export const UPDATE_MARKETS_AT_RISK_SEEN_MODAL =
+  "UPDATE_MARKETS_AT_RISK_SEEN_MODAL";
+
+export function setMarketsAtRiskModalAsSeen(flag) {
+  return { type: UPDATE_MARKETS_AT_RISK_SEEN_MODAL, flag };
+}

--- a/src/modules/modal/components/common/common.styles.less
+++ b/src/modules/modal/components/common/common.styles.less
@@ -534,7 +534,8 @@ div.ErrorField:focus {
   }
 }
 
-.ModalMarketReview {
+.ModalMarketReview,
+.ModalMarketsV2Alert {
   background-color: @color-white;
   border-radius: 0.32rem;
   color: @color-almostblack;
@@ -576,7 +577,8 @@ div.ErrorField:focus {
   font-weight: bold;
 }
 
-.ModalMarketReview__TextBox {
+.ModalMarketReview__TextBox,
+.ModalMarketsV2Alert__Markets {
   background-color: @color-offwhite;
   color: @color-almostblack;
   margin: 0 2rem 1.5rem;
@@ -641,6 +643,69 @@ div.ErrorField:focus {
     border: 0;
     margin: 0;
     padding: 0;
+  }
+}
+
+.ModalMarketsV2Alert {
+  padding: 2.125rem 0 1.5rem;
+
+  > h1 {
+    color: @color-cuttoff-red;
+    margin: 0;
+  }
+}
+
+.ModalMarketsV2Alert__Header,
+.ModalMarketsV2Alert__Warning {
+  color: @color-almostblack;
+  font-size: 0.875rem;
+  font-weight: normal;
+  padding: 0 2rem 1rem;
+  text-align: left;
+
+  a {
+    text-decoration: underline;
+  }
+
+  > p {
+    line-height: 18px;
+    margin: 1rem 0;
+  }
+
+  > p:last-of-type {
+    font-weight: bold;
+    margin: 1rem 0 0;
+  }
+}
+
+.ModalMarketsV2Alert__Warning {
+  color: @color-cuttoff-red;
+  padding: 0 2rem 1rem;
+
+  > p {
+    margin: 0;
+  }
+}
+
+.ModalMarketsV2Alert__Markets {
+  background-color: @color-offwhite;
+  color: @color-almostblack;
+  margin: 0 2rem;
+  overflow: auto;
+  overflow-wrap: break-word;
+  padding: 1.5rem;
+  text-align: left;
+  text-decoration-line: underline;
+  width: 89%;
+
+  > div {
+    font-size: 0.875rem;
+    font-weight: normal;
+    margin: 0 0 1rem;
+  }
+
+  > div:last-of-type {
+    margin: 0;
   }
 }
 

--- a/src/modules/modal/components/modal-disclaimer.jsx
+++ b/src/modules/modal/components/modal-disclaimer.jsx
@@ -35,7 +35,9 @@ export default class ModalDisclaimer extends Component {
   }
 
   checkCheckbox(didCheck) {
-    if (this.state.didScroll) this.setState({ didCheck });
+    setTimeout(() => {
+      if (this.state.didScroll) this.setState({ didCheck });
+    });
   }
 
   render() {

--- a/src/modules/modal/components/modal-v2-markets-alert.jsx
+++ b/src/modules/modal/components/modal-v2-markets-alert.jsx
@@ -1,0 +1,137 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import Styles from "modules/modal/components/common/common.styles";
+
+import ModalActions from "modules/modal/components/common/modal-actions";
+import Checkbox from "src/modules/common/components/checkbox/checkbox";
+import { MY_POSITIONS } from "modules/routes/constants/views";
+import { CUTOFF_READABLE } from "modules/markets/constants/cutoff-date";
+import makePath from "modules/routes/helpers/make-path";
+import MarketLink from "modules/market/components/market-link/market-link";
+
+export default class ModalMarketsV2Alert extends Component {
+  static propTypes = {
+    account: PropTypes.string.isRequired,
+    closeModal: PropTypes.func.isRequired,
+    markModalAsSeen: PropTypes.func.isRequired,
+    markModalAsUnSeen: PropTypes.func.isRequired,
+    history: PropTypes.object.isRequired,
+    markets: PropTypes.array.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      didCheck: false
+    };
+
+    this.checkCheckbox = this.checkCheckbox.bind(this);
+  }
+
+  checkCheckbox() {
+    const { account } = this.props;
+    this.setState({ didCheck: !this.state.didCheck }, () => {
+      if (this.state.didCheck) {
+        this.props.markModalAsSeen(account);
+      } else {
+        this.props.markModalAsUnSeen(account);
+      }
+    });
+  }
+
+  render() {
+    const { closeModal, markets } = this.props;
+
+    const { didCheck } = this.state;
+    const marketsRows = markets.map(market => (
+      <div key={market.id}>
+        <MarketLink id={market.id} newTab>
+          {market.description}
+        </MarketLink>
+      </div>
+    ));
+
+    return (
+      <section className={Styles.ModalMarketsV2Alert}>
+        <h1>Alert</h1>
+        <div className={Styles.ModalMarketsV2Alert__Header}>
+          <p>
+            You have open orders and/or positions on markets that expire after
+            the cutoff date for the Augur v2 release phase. Markets ending after{" "}
+            {CUTOFF_READABLE} are at a higher risk of resolving incorrectly.{" "}
+            <a
+              href="http://docs.augur.net"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Read more
+            </a>
+          </p>
+
+          <p>You may be at risk in the following markets:</p>
+        </div>
+
+        <div className={Styles.ModalMarketsV2Alert__Markets}>{marketsRows}</div>
+
+        <div className={Styles.ModalMarketsV2Alert__Warning}>
+          <p>
+            Users are advised to consider closing any positions and cancelling
+            any open orders in these markets (unless such orders would decrease
+            their current exposure).
+          </p>
+        </div>
+
+        <div
+          className={Styles.ModalMarketReview__checkbox}
+          role="button"
+          tabIndex="0"
+          onClick={e => {
+            e.preventDefault();
+            this.checkCheckbox();
+          }}
+        >
+          <label htmlFor="marketReview">
+            <Checkbox
+              id="marketReview"
+              type="checkbox"
+              value={didCheck}
+              isChecked={didCheck}
+              onClick={e => {
+                e.preventDefault();
+                this.checkCheckbox();
+              }}
+            />
+            Don’t show this message anymore
+          </label>
+        </div>
+
+        <div className={Styles.ModalMarketReview__ActionButtons}>
+          <ModalActions
+            buttons={[
+              {
+                label: "close",
+                type: "gray",
+                action: () => {
+                  closeModal();
+                }
+              }
+            ]}
+          />
+          <ModalActions
+            buttons={[
+              {
+                label: "view portfolio",
+                type: "purple",
+                action: () => {
+                  this.props.history.push(makePath(MY_POSITIONS));
+                }
+              }
+            ]}
+          />
+        </div>
+      </section>
+    );
+  }
+}

--- a/src/modules/modal/components/modal-view.jsx
+++ b/src/modules/modal/components/modal-view.jsx
@@ -15,6 +15,7 @@ import ModalParticipate from "modules/modal/containers/modal-participate";
 import ModalMigrateMarket from "modules/modal/containers/modal-migrate-market";
 import ModalNetworkConnect from "modules/modal/containers/modal-network-connect";
 import ModalDisclaimer from "modules/modal/containers/modal-disclaimer";
+import ModalMarketsV2Alert from "modules/modal/containers/modal-v2-markets-alert";
 import ModalMarketReview from "modules/modal/containers/modal-market-review";
 import ModalGasPrice from "modules/modal/containers/modal-gas-price";
 import ModalClaimTradingProceeds from "modules/modal/containers/modal-claim-trading-proceeds";
@@ -86,6 +87,9 @@ export default class ModalView extends Component {
           )}
           {modal.type === TYPES.MODAL_DISCLAIMER && (
             <ModalDisclaimer {...modal} />
+          )}
+          {modal.type === TYPES.MODAL_V2_MARKETS_ALERT && (
+            <ModalMarketsV2Alert {...modal} />
           )}
           {modal.type === TYPES.MODAL_MARKET_REVIEW && (
             <ModalMarketReview {...modal} />

--- a/src/modules/modal/constants/local-storage-keys.js
+++ b/src/modules/modal/constants/local-storage-keys.js
@@ -1,2 +1,3 @@
 export const DISCLAIMER_SEEN = "disclaimerSeen";
 export const MARKET_REVIEW_SEEN = "marketReviewSeen";
+export const V2_MARKETS_REVIEW_SEEN = "v2MarketsReviewSeen";

--- a/src/modules/modal/containers/modal-v2-markets-alert.js
+++ b/src/modules/modal/containers/modal-v2-markets-alert.js
@@ -1,0 +1,59 @@
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import ModalMarketsV2Alert from "modules/modal/components/modal-v2-markets-alert";
+import { closeModal } from "modules/modal/actions/close-modal";
+import { V2_MARKETS_REVIEW_SEEN } from "src/modules/modal/constants/local-storage-keys";
+import { selectMarkets } from "src/modules/markets/selectors/markets-all";
+import { isPastV2Cutoff } from "modules/markets/helpers/is-market-past-v2-cutoff";
+
+const localStorageRef = typeof window !== "undefined" && window.localStorage;
+
+const mapStateToProps = state => {
+  const markets = selectMarkets(state);
+
+  const hasPositionsInCutoffMarkets = markets
+    .filter(market => isPastV2Cutoff(market.endTime.timestamp))
+    .filter(market => market && market.myPositionOutcomes);
+
+  return {
+    account: state.loginAccount.address,
+    modal: state.modal,
+    hasPositionsInCutoffMarkets: hasPositionsInCutoffMarkets.legnth > 0,
+    markets: hasPositionsInCutoffMarkets
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  markModalAsSeen: account => {
+    if (localStorageRef) {
+      const accountsSeen =
+        JSON.parse(localStorage.getItem(V2_MARKETS_REVIEW_SEEN)) || {};
+      accountsSeen[account] = true;
+      localStorageRef.setItem(
+        V2_MARKETS_REVIEW_SEEN,
+        JSON.stringify(accountsSeen)
+      );
+    }
+  },
+  markModalAsUnSeen: account => {
+    if (localStorageRef) {
+      const accountsSeen =
+        JSON.parse(localStorage.getItem(V2_MARKETS_REVIEW_SEEN)) || {};
+      delete accountsSeen[account];
+      localStorageRef.setItem(
+        V2_MARKETS_REVIEW_SEEN,
+        JSON.stringify(accountsSeen)
+      );
+    }
+  },
+  closeModal: () => {
+    dispatch(closeModal());
+  }
+});
+
+export default withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(ModalMarketsV2Alert)
+);

--- a/src/modules/modal/reducers/markets-at-risk-seen-this-session.js
+++ b/src/modules/modal/reducers/markets-at-risk-seen-this-session.js
@@ -1,0 +1,20 @@
+import { UPDATE_MARKETS_AT_RISK_SEEN_MODAL } from "modules/modal/actions/update-markets-at-risk-seen-modal";
+import { CLEAR_LOGIN_ACCOUNT } from "modules/auth/actions/update-login-account";
+import { RESET_STATE } from "modules/app/actions/reset-state";
+
+const DEFAULT_STATE = false;
+
+export default function(
+  marketsAtRiskModalSeenThisSession = DEFAULT_STATE,
+  { type, flag }
+) {
+  switch (type) {
+    case UPDATE_MARKETS_AT_RISK_SEEN_MODAL:
+      return flag;
+    case RESET_STATE:
+    case CLEAR_LOGIN_ACCOUNT:
+      return DEFAULT_STATE;
+    default:
+      return marketsAtRiskModalSeenThisSession;
+  }
+}

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -23,6 +23,7 @@ import marketTradingHistory from "modules/markets/reducers/market-trading-histor
 import marketReportState from "modules/reports/reducers/market-report-state";
 import marketsData from "modules/markets/reducers/markets-data";
 import marketsWithAccountReport from "modules/reports/reducers/markets-with-account-report";
+import marketsAtRiskModalSeenThisSession from "modules/modal/reducers/markets-at-risk-seen-this-session";
 import modal from "modules/modal/reducers/modal";
 import newMarket from "modules/markets/reducers/new-market";
 import notifications from "modules/notifications/reducers/notifications";
@@ -71,6 +72,7 @@ export function createReducer() {
     marketTradingHistory,
     marketsData,
     marketsWithAccountReport,
+    marketsAtRiskModalSeenThisSession,
     modal,
     newMarket,
     notifications,


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/2121

<img width="381" alt="Screen Shot 2019-05-13 at 9 39 24 AM" src="https://user-images.githubusercontent.com/1683736/57626039-12416b00-7563-11e9-97c5-c18ad0fc7033.png">

When a user logs in:
- if the user has positions in markets that expired post-V2 show modal (unless they have opted out)
- Allow T&C modal to appear first before showing this modal
- show modal every 24 hours, assuming the tab doesn't close
