### PR TITLE
fix mobile padding/margin

### DIFF
--- a/src/modules/modal/components/common/common.styles.less
+++ b/src/modules/modal/components/common/common.styles.less
@@ -639,6 +639,10 @@ div.ErrorField:focus {
     margin-right: 1rem;
   }
 
+  > div:last-of-type button {
+    padding: 1rem;
+  }
+
   > div {
     border: 0;
     margin: 0;
@@ -652,6 +656,10 @@ div.ErrorField:focus {
 
   > h1 {
     color: @color-cuttoff-red;
+    margin: 0;
+  }
+
+  @media @breakpoint-mobile {
     margin: 0;
   }
 }


### PR DESCRIPTION
https://github.com/AugurProject/augur/issues/2121

## Design feedback below

- Very little space on mobile for the scrollable view. Can we update the top and bottom padding on mobile

- Also, the "view portfolio" button is broken on mobile. Let's reduce the padding of the content to 16px to fix that.


<img src="https://user-images.githubusercontent.com/1683736/57862961-3ac99f00-77c7-11e9-9fb5-8829800f838f.png" width="300" />
