### PR TITLE
depends on augur-node PR: 2328 filter cleanup

### DIFF
--- a/src/modules/app/actions/load-universe.js
+++ b/src/modules/app/actions/load-universe.js
@@ -6,7 +6,6 @@ import syncUniverse from "modules/universe/actions/sync-universe";
 import getReportingCycle from "modules/universe/selectors/reporting-cycle";
 import { syncBlockchain } from "modules/app/actions/sync-blockchain";
 import { listenToUpdates } from "modules/events/actions/listen-to-updates";
-import loadCategories from "modules/categories/actions/load-categories";
 import { loadMarketsToReportOn } from "modules/reports/actions/load-markets-to-report-on";
 import logError from "utils/log-error";
 

--- a/src/modules/app/actions/load-universe.js
+++ b/src/modules/app/actions/load-universe.js
@@ -53,7 +53,6 @@ export const loadUniverse = (universeId, history, callback = logError) => (
           callback(null);
         })
       );
-      dispatch(loadCategories());
       dispatch(loadMarketsToReportOn());
     }
   );

--- a/src/modules/categories/actions/load-categories.js
+++ b/src/modules/categories/actions/load-categories.js
@@ -5,28 +5,34 @@ import {
 } from "modules/categories/actions/update-categories";
 import logError from "utils/log-error";
 
-const loadCategories = (callback = logError) => (dispatch, getState) => {
+const loadCategories = (params = {}, callback = logError) => (
+  dispatch,
+  getState
+) => {
   const { universe } = getState();
   if (!universe.id) return callback(null);
-  augur.markets.getCategories({ universe: universe.id }, (err, categories) => {
-    if (err) return callback(err);
-    if (categories == null) return callback(null);
-    dispatch(clearCategories());
+  augur.markets.getCategories(
+    { ...params, universe: universe.id },
+    (err, categories) => {
+      if (err) return callback(err);
+      if (categories == null) return callback(null);
+      dispatch(clearCategories());
 
-    // Categories currently don't allow the user to specify how they should be
-    // sorted; to enable users to discover interesting markets, sort categories
-    // and their nested tags by non-finalized open interest. Do this here
-    // because this sort is expensive and we only want to do it once, upstream
-    // of redux store. Possibly this could be done in augur-node instead,
-    // such that the UI would just rely on categories already being sorted.
-    categories.sort(sortByNonFinalizedOpenInterestDescending);
-    categories.forEach(c =>
-      c.tags.sort(sortByNonFinalizedOpenInterestDescending)
-    );
+      // Categories currently don't allow the user to specify how they should be
+      // sorted; to enable users to discover interesting markets, sort categories
+      // and their nested tags by non-finalized open interest. Do this here
+      // because this sort is expensive and we only want to do it once, upstream
+      // of redux store. Possibly this could be done in augur-node instead,
+      // such that the UI would just rely on categories already being sorted.
+      categories.sort(sortByNonFinalizedOpenInterestDescending);
+      categories.forEach(c =>
+        c.tags.sort(sortByNonFinalizedOpenInterestDescending)
+      );
 
-    dispatch(updateCategories(categories));
-    callback(null, categories);
-  });
+      dispatch(updateCategories(categories));
+      callback(null, categories);
+    }
+  );
 };
 
 export default loadCategories;

--- a/src/modules/markets/actions/load-markets.js
+++ b/src/modules/markets/actions/load-markets.js
@@ -134,7 +134,7 @@ export const loadMarketsByFilter = (filterOptions, cb = () => {}) => (
     case MARKET_LIQUIDITY_100: {
       sort.sortBy = "liquidityTokens";
       sort.isSortDescending = true;
-      sort.liquiditySortSpreadPercent = 0.99; // WARNING this is 99% instead of 100% because extremely large quantity orders with small prices are effectively a denial of service attack against the augur-node liquidity algorithm
+      sort.liquiditySortSpreadPercent = 1.0;
       break;
     }
     default: {

--- a/src/modules/markets/actions/load-markets.js
+++ b/src/modules/markets/actions/load-markets.js
@@ -1,7 +1,7 @@
 import { augur } from "services/augurjs";
 import { constants } from "services/constants";
 import logError from "utils/log-error";
-import { parallel } from "async";
+import loadCategories from "modules/categories/actions/load-categories";
 import { CUTOFF } from "modules/markets/constants/cutoff-date";
 import {
   MARKET_CREATION_TIME,
@@ -82,9 +82,7 @@ export const loadMarketsByFilter = (filterOptions, cb = () => {}) => (
   getState
 ) => {
   const { universe } = getState();
-  const filter = [];
   const sort = {};
-  const parallelParams = {};
   switch (filterOptions.sort) {
     case MARKET_RECENTLY_TRADED: {
       // Sort By Recently Traded:
@@ -168,66 +166,38 @@ export const loadMarketsByFilter = (filterOptions, cb = () => {}) => (
   switch (filterOptions.filter) {
     case MARKET_REPORTING: {
       // reporting markets only:
-      filter.push([
+      params.reportingState = [
         REPORTING_STATE.DESIGNATED_REPORTING,
         REPORTING_STATE.OPEN_REPORTING,
         REPORTING_STATE.CROWDSOURCING_DISPUTE,
         REPORTING_STATE.AWAITING_NEXT_WINDOW
-      ]);
-      filter.forEach(filterType => {
-        parallelParams[filterType] = next =>
-          augur.markets.getMarkets(
-            { ...params, reportingState: filterType },
-            next
-          );
-      });
+      ];
       break;
     }
     case MARKET_CLOSED: {
       // resolved markets only:
-      filter.push([
+      params.reportingState = [
         REPORTING_STATE.AWAITING_FINALIZATION,
         REPORTING_STATE.FINALIZED
-      ]);
-      filter.forEach(filterType => {
-        parallelParams[filterType] = next =>
-          augur.markets.getMarkets(
-            { ...params, reportingState: filterType },
-            next
-          );
-      });
+      ];
       break;
     }
     default: {
       // open markets only:
-      filter.push(REPORTING_STATE.PRE_REPORTING);
-      filter.forEach(filterType => {
-        parallelParams[filterType] = next =>
-          augur.markets.getMarkets(
-            { ...params, reportingState: filterType },
-            next
-          );
-      });
+      params.reportingState = [REPORTING_STATE.PRE_REPORTING];
       break;
     }
   }
-  parallel(parallelParams, (err, filteredMarkets) => {
-    let finalizedMarketList = [];
+
+  augur.markets.getMarkets(params, (err, filteredMarkets) => {
     if (err) return cb(err);
-    filter.forEach(filterType => {
-      if (
-        filteredMarkets[filterType] &&
-        filteredMarkets[filterType].length > 0
-      ) {
-        finalizedMarketList = finalizedMarketList.concat(
-          filteredMarkets[filterType]
-        );
-      }
-    });
 
     setTimeout(() => {
       dispatch(updateAppStatus(HAS_LOADED_MARKETS, true));
     }, 2000);
-    return cb(null, finalizedMarketList);
+
+    // load categories here
+    dispatch(loadCategories(params));
+    return cb(null, filteredMarkets);
   });
 };

--- a/src/modules/markets/actions/load-markets.test.js
+++ b/src/modules/markets/actions/load-markets.test.js
@@ -10,6 +10,7 @@ describe(`modules/markets/actions/load-markets`, () => {
   const { REPORTING_STATE } = constants;
   augur.markets = jest.fn(() => {});
   augur.markets.getMarkets = jest.fn(() => {});
+  augur.markets.getCategories = jest.fn(() => {});
 
   const {
     loadMarketsByFilter


### PR DESCRIPTION
UI changes to filter categories after getMarkets is called with filtering parameters

marked as WIP don't merge this up until augur-node PR on branch `2328-filter-cleanup` is merged.