### PR TITLE
remove overflow ellipse for mobile on market trading page

### DIFF
--- a/src/modules/market/components/market-header/market-header.styles.less
+++ b/src/modules/market/components/market-header/market-header.styles.less
@@ -144,9 +144,7 @@
 
     @media @breakpoint-mobile-small {
       display: block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      white-space: pre-wrap;
     }
   }
 }

--- a/src/modules/market/components/market-header/market-header.styles.less
+++ b/src/modules/market/components/market-header/market-header.styles.less
@@ -144,7 +144,7 @@
 
     @media @breakpoint-mobile-small {
       display: block;
-      white-space: pre-wrap;
+      white-space: normal;
     }
   }
 }


### PR DESCRIPTION
![Screen Shot 2019-07-15 at 11 05 46 AM](https://user-images.githubusercontent.com/3970376/61232926-06a22a00-a6f5-11e9-8755-6acb8f9b846c.png)


additional details gets cut off on mobile. all user sees is ...

removed overflow and text-overflow, now user can see the text.

![image](https://user-images.githubusercontent.com/3970376/61233038-39e4b900-a6f5-11e9-8cb5-f1883c35f591.png)
