### PR TITLE
merge categories around, only clear when no category is passed in

### DIFF
--- a/src/modules/categories/actions/load-categories.js
+++ b/src/modules/categories/actions/load-categories.js
@@ -5,10 +5,11 @@ import {
 } from "modules/categories/actions/update-categories";
 import logError from "utils/log-error";
 
-const loadCategories = (params = {}, callback = logError) => (
-  dispatch,
-  getState
-) => {
+const loadCategories = (
+  params = {},
+  refreshCategories,
+  callback = logError
+) => (dispatch, getState) => {
   const { universe } = getState();
   if (!universe.id) return callback(null);
   augur.markets.getCategories(
@@ -16,7 +17,7 @@ const loadCategories = (params = {}, callback = logError) => (
     (err, categories) => {
       if (err) return callback(err);
       if (categories == null) return callback(null);
-      dispatch(clearCategories());
+      if (refreshCategories) dispatch(clearCategories());
 
       categories.sort(sortByLiquidityTokensDescending);
       categories.forEach(c => c.tags.sort(sortByLiquidityTokensDescending));

--- a/src/modules/categories/reducers/categories-data.js
+++ b/src/modules/categories/reducers/categories-data.js
@@ -10,7 +10,17 @@ const DEFAULT_STATE = [];
 export default function(categories = DEFAULT_STATE, { type, data }) {
   switch (type) {
     case UPDATE_CATEGORIES:
-      return data.categories; // NB we ignore pre-existing categories and so UPDATE_CATEGORIES replaces any previous categories. This is consistent with augur.getCategories() which always returns all categories and has no natural support for incrementally updating categories
+      return Array.from(
+        new Set([
+          ...categories.map(c => c.categoryName),
+          ...data.categories.map(c => c.categoryName)
+        ])
+      ).map(
+        k =>
+          data.categories.find(d => d.categoryName === k)
+            ? data.categories.find(d => d.categoryName === k)
+            : categories.find(d => d.categoryName === k)
+      );
     case RESET_STATE:
     case CLEAR_CATEGORIES:
       return DEFAULT_STATE;

--- a/src/modules/markets/actions/load-markets.js
+++ b/src/modules/markets/actions/load-markets.js
@@ -197,7 +197,7 @@ export const loadMarketsByFilter = (filterOptions, cb = () => {}) => (
     }, 2000);
 
     // load categories here
-    dispatch(loadCategories(params));
+    dispatch(loadCategories(params, !params.category));
     return cb(null, filteredMarkets);
   });
 };


### PR DESCRIPTION
keep categories state and only clear if category (remove categories collection in redux state) isn't passed into query filter. The effect is the side categories are not cleared if the user clicks on a category. 


![image](https://user-images.githubusercontent.com/3970376/61493368-04e89880-a979-11e9-9b01-01b44b79b834.png)
