### PR TITLE
first poke at adding checkbox to require markets to have a min initia…

### DIFF
--- a/src/modules/filter-sort/actions/update-filter-sort-options.js
+++ b/src/modules/filter-sort/actions/update-filter-sort-options.js
@@ -6,6 +6,7 @@ export const MARKET_MAX_SPREAD = "maxSpreadPercent";
 export const TRANSACTION_PERIOD = "transactionPeriod";
 export const PAST_CUTOFF = "hidePostV2Markets";
 export const EXPERIMENTAL_INVALID = "experimentalInvalid";
+export const INSECURE_MARKETS = "hideInsecureMarkets";
 
 export function updateFilterSortOptions(optionKey, optionValue) {
   return {

--- a/src/modules/filter-sort/components/filter-dropdowns/filter-dropdowns.jsx
+++ b/src/modules/filter-sort/components/filter-dropdowns/filter-dropdowns.jsx
@@ -95,6 +95,8 @@ export default class FilterSearch extends Component {
     updateMaxFee: PropTypes.func.isRequired,
     hidePostV2Markets: PropTypes.bool.isRequired,
     updateHidePostV2Markets: PropTypes.func.isRequired,
+    hideInsecureMarkets: PropTypes.bool.isRequired,
+    updateHideInsecureMarkets: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
     hasPositionsInCutoffMarkets: PropTypes.bool.isRequired,
@@ -111,6 +113,7 @@ export default class FilterSearch extends Component {
     this.goToPageOne = this.goToPageOne.bind(this);
     this.changeHidePastCutoff = this.changeHidePastCutoff.bind(this);
     this.changeExperimentalInvalid = this.changeExperimentalInvalid.bind(this);
+    this.changeHideInsureMarkets = this.changeHideInsureMarkets.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -144,6 +147,7 @@ export default class FilterSearch extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     } = this.props;
 
@@ -155,6 +159,7 @@ export default class FilterSearch extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     });
   }
@@ -167,6 +172,7 @@ export default class FilterSearch extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     } = this.props;
 
@@ -178,6 +184,7 @@ export default class FilterSearch extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     });
   }
@@ -190,6 +197,7 @@ export default class FilterSearch extends Component {
       maxSpreadPercent,
       updateFilter,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     } = this.props;
 
@@ -201,6 +209,7 @@ export default class FilterSearch extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     });
   }
@@ -213,6 +222,7 @@ export default class FilterSearch extends Component {
       updateMaxSpread,
       updateFilter,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     } = this.props;
 
@@ -224,6 +234,31 @@ export default class FilterSearch extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
+      hideInsecureMarkets,
+      experimentalInvalid
+    });
+  }
+
+  changeHideInsureMarkets() {
+    const {
+      filter,
+      sort,
+      maxFee,
+      maxSpreadPercent,
+      updateFilter,
+      hidePostV2Markets,
+      hideInsecureMarkets,
+      experimentalInvalid,
+      updateHideInsecureMarkets
+    } = this.props;
+    updateHideInsecureMarkets(!hideInsecureMarkets);
+    updateFilter({
+      filter,
+      sort,
+      maxFee,
+      maxSpreadPercent,
+      hidePostV2Markets,
+      hideInsecureMarkets: !hideInsecureMarkets,
       experimentalInvalid
     });
   }
@@ -237,6 +272,7 @@ export default class FilterSearch extends Component {
       updateFilter,
       hidePostV2Markets,
       updateHidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     } = this.props;
     updateHidePostV2Markets(!hidePostV2Markets);
@@ -246,6 +282,7 @@ export default class FilterSearch extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets: !hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     });
   }
@@ -258,6 +295,7 @@ export default class FilterSearch extends Component {
       maxSpreadPercent,
       updateFilter,
       hidePostV2Markets,
+      hideInsecureMarkets,
       updateExperimentalInvalid,
       experimentalInvalid
     } = this.props;
@@ -268,6 +306,7 @@ export default class FilterSearch extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid: !experimentalInvalid
     });
   }
@@ -278,6 +317,7 @@ export default class FilterSearch extends Component {
       defaultSort,
       defaultMaxFee,
       hidePostV2Markets,
+      hideInsecureMarkets,
       experimentalInvalid
     } = this.props;
 
@@ -347,6 +387,17 @@ export default class FilterSearch extends Component {
                 </p>
               </ReactTooltip>
             </label>
+          </div>
+          <div>
+            <Checkbox
+              id="insure-markets"
+              type="checkbox"
+              name="hideInsecureMarkets"
+              isChecked={hideInsecureMarkets}
+              value={hideInsecureMarkets}
+              onClick={this.changeHideInsureMarkets}
+            />{" "}
+            <label htmlFor="post-cutoff">hide insecure markets</label>
           </div>
         </div>
       </div>

--- a/src/modules/filter-sort/containers/filter-dropdowns.js
+++ b/src/modules/filter-sort/containers/filter-dropdowns.js
@@ -9,7 +9,8 @@ import {
   MARKET_MAX_FEES,
   MARKET_MAX_SPREAD,
   PAST_CUTOFF,
-  EXPERIMENTAL_INVALID
+  EXPERIMENTAL_INVALID,
+  INSECURE_MARKETS
 } from "modules/filter-sort/actions/update-filter-sort-options";
 
 const mapStateToProps = state => ({
@@ -31,7 +32,11 @@ const mapDispatchToProps = dispatch => ({
   updateHidePostV2Markets: hidePostV2Markets =>
     dispatch(updateFilterSortOptions(PAST_CUTOFF, hidePostV2Markets)),
   updateExperimentalInvalid: experimentalInvalid =>
-    dispatch(updateFilterSortOptions(EXPERIMENTAL_INVALID, experimentalInvalid))
+    dispatch(
+      updateFilterSortOptions(EXPERIMENTAL_INVALID, experimentalInvalid)
+    ),
+  updateHideInsecureMarkets: hideInsecureMarkets =>
+    dispatch(updateFilterSortOptions(INSECURE_MARKETS, hideInsecureMarkets))
 });
 
 const FilterDropdownsContainer = withRouter(

--- a/src/modules/filter-sort/reducers/filter-sort-options.js
+++ b/src/modules/filter-sort/reducers/filter-sort-options.js
@@ -10,7 +10,8 @@ import {
   MARKET_MAX_SPREAD,
   TRANSACTION_PERIOD,
   PAST_CUTOFF,
-  EXPERIMENTAL_INVALID
+  EXPERIMENTAL_INVALID,
+  INSECURE_MARKETS
 } from "modules/filter-sort/actions/update-filter-sort-options";
 import { MAX_FEE_05_PERCENT } from "src/modules/filter-sort/constants/market-max-fees";
 import {
@@ -31,7 +32,8 @@ const DEFAULT_STATE = {
   [MARKET_MAX_SPREAD]: maxSpreadSelection || MAX_SPREAD_10_PERCENT,
   [TRANSACTION_PERIOD]: DAY,
   [PAST_CUTOFF]: true,
-  [EXPERIMENTAL_INVALID]: true
+  [EXPERIMENTAL_INVALID]: true,
+  [INSECURE_MARKETS]: true
 };
 
 const KEYS = Object.keys(DEFAULT_STATE);

--- a/src/modules/markets-list/components/markets-header/markets-header.jsx
+++ b/src/modules/markets-list/components/markets-header/markets-header.jsx
@@ -24,7 +24,8 @@ export default class MarketsHeader extends Component {
     updateFilter: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
     hasPositionsInCutoffMarkets: PropTypes.bool.isRequired,
-    experimentalInvalid: PropTypes.bool.isRequired
+    experimentalInvalid: PropTypes.bool.isRequired,
+    hideInsecureMarkets: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -77,7 +78,8 @@ export default class MarketsHeader extends Component {
       experimentalInvalid,
       updateFilter,
       history,
-      hasPositionsInCutoffMarkets
+      hasPositionsInCutoffMarkets,
+      hideInsecureMarkets
     } = this.props;
     const s = this.state;
 
@@ -97,6 +99,7 @@ export default class MarketsHeader extends Component {
               location={location}
               hasPositionsInCutoffMarkets={hasPositionsInCutoffMarkets}
               maxSpreadPercent={maxSpreadPercent}
+              hideInsecureMarkets={hideInsecureMarkets}
             />
           </div>
           <div className={Styles.MarketsHeader__search}>

--- a/src/modules/markets-list/components/markets-view.jsx
+++ b/src/modules/markets-list/components/markets-view.jsx
@@ -26,6 +26,7 @@ export default class MarketsView extends Component {
     defaultMaxSpread: PropTypes.string.isRequired,
     defaultHidePastCutoff: PropTypes.bool.isRequired,
     defaultExperimentalInvalid: PropTypes.bool.isRequired,
+    defaultHideInscureMarkets: PropTypes.bool.isRequired,
     loadDisputing: PropTypes.func.isRequired
   };
 
@@ -45,6 +46,7 @@ export default class MarketsView extends Component {
       maxSpreadPercent: props.defaultMaxSpread,
       hidePostV2Markets: props.defaultHidePastCutoff,
       experimentalInvalid: props.defaultExperimentalInvalid,
+      hideInsecureMarkets: props.defaultHideInscureMarkets,
       filterSortedMarkets: []
     };
 
@@ -77,7 +79,8 @@ export default class MarketsView extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
-      experimentalInvalid
+      experimentalInvalid,
+      hideInsecureMarkets
     } = params;
     this.setState(
       {
@@ -86,7 +89,8 @@ export default class MarketsView extends Component {
         maxFee,
         maxSpreadPercent,
         hidePostV2Markets,
-        experimentalInvalid
+        experimentalInvalid,
+        hideInsecureMarkets
       },
       this.updateFilteredMarkets
     );
@@ -100,7 +104,8 @@ export default class MarketsView extends Component {
       maxFee,
       maxSpreadPercent,
       hidePostV2Markets,
-      experimentalInvalid
+      experimentalInvalid,
+      hideInsecureMarkets
     } = this.state;
     loadMarketsByFilter(
       {
@@ -111,7 +116,8 @@ export default class MarketsView extends Component {
         maxFee,
         maxSpreadPercent,
         hidePostV2Markets,
-        experimentalInvalid
+        experimentalInvalid,
+        hideInsecureMarkets
       },
       (err, filterSortedMarkets) => {
         if (err) return console.log("Error loadMarketsFilter:", err);
@@ -138,7 +144,8 @@ export default class MarketsView extends Component {
       maxSpreadPercent,
       hidePostV2Markets,
       experimentalInvalid,
-      filterSortedMarkets
+      filterSortedMarkets,
+      hideInsecureMarkets
     } = this.state;
 
     return (
@@ -160,6 +167,7 @@ export default class MarketsView extends Component {
           maxSpreadPercent={maxSpreadPercent}
           hidePostV2Markets={hidePostV2Markets}
           experimentalInvalid={experimentalInvalid}
+          hideInsecureMarkets={hideInsecureMarkets}
           updateFilter={this.updateFilter}
           history={history}
           hasPositionsInCutoffMarkets={hasPositionsInCutoffMarkets}

--- a/src/modules/markets-list/containers/markets-view-container.js
+++ b/src/modules/markets-list/containers/markets-view-container.js
@@ -42,7 +42,8 @@ const mapStateToProps = (state, { location }) => {
     defaultMaxFee: state.filterSortOptions.maxFee,
     defaultMaxSpread: state.filterSortOptions.maxSpreadPercent,
     defaultHidePastCutoff: state.filterSortOptions.hidePostV2Markets,
-    defaultExperimentalInvalid: state.filterSortOptions.experimentalInvalid
+    defaultExperimentalInvalid: state.filterSortOptions.experimentalInvalid,
+    defaultHideInscureMarkets: state.filterSortOptions.hideInsecureMarkets
   };
 };
 

--- a/src/modules/markets/constants/cutoff-date.js
+++ b/src/modules/markets/constants/cutoff-date.js
@@ -1,8 +1,9 @@
 import { formatDate } from "utils/format-date";
 
 // Cutoff Date
-// Sunday, September 15, 2019 11:59:59 PM
+// Wednesday, January 1, 2020 12:00:00 AM
+// old cutoff date Sunday, September 15, 2019 11:59:59 PM
 
-export const CUTOFF = 1568591999000;
+export const CUTOFF = 1577836800000;
 export const CUTOFF_READABLE = formatDate(new Date(CUTOFF)).formattedUtc;
 export const CUTOFF_URL = "https://augur.net/blog/v1-cutoff";

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -187,3 +187,8 @@ export function getMinutesMinusHoursRemaining(
   const hours = getHours * 60;
   return getMinutesRemaining(endUnixTimestamp, startUnixTimestamp) - hours;
 }
+
+export function numberOfWeeksUntilDate(timestamp, cutoff) {
+  const weeks = moment(timestamp).diff(cutoff, "week");
+  return Math.abs(weeks);
+}


### PR DESCRIPTION
…l rep staked on market initial reporting contract


adding new checkbox

![image](https://user-images.githubusercontent.com/3970376/64309037-e8241680-cf60-11e9-8b03-d1920f8d7e43.png)


and calculate min Initial reporting REP needed for filtering out markets.