### PR TITLE
Add according trading page

### DIFF
--- a/src/modules/market/components/market-header/market-header.jsx
+++ b/src/modules/market/components/market-header/market-header.jsx
@@ -110,6 +110,11 @@ export default class MarketHeader extends Component {
       details += warningText;
     }
 
+    let marketDescription = market.description;
+    if (market.resolutionSource) {
+      marketDescription = `${description} According to
+      ${market.resolutionSource}`;
+    }
     return (
       <section className={Styles.MarketHeader}>
         <div
@@ -137,7 +142,9 @@ export default class MarketHeader extends Component {
         </div>
         <div className={Styles[`MarketHeader__main-values`]}>
           <div className={Styles.MarketHeader__descContainer}>
-            <h1 className={Styles.MarketHeader__description}>{description}</h1>
+            <h1 className={Styles.MarketHeader__description}>
+              {marketDescription}
+            </h1>
             <div className={Styles.MarketHeader__descriptionContainer}>
               <div
                 className={Styles.MarketHeader__details}

--- a/src/modules/reporting/components/common/invalid-message.jsx
+++ b/src/modules/reporting/components/common/invalid-message.jsx
@@ -14,7 +14,9 @@ const InvalidMessage = () => (
       </span>
     </div>
     <div>
-      <span className={Styles.bolden}>Definition: </span>The resolution source is an actor that reports on or decides the results of a market.
+      <span className={Styles.bolden}>Definition: </span>
+      The resolution source is an actor that reports on or decides the results
+      of a market.
     </div>
     <div>
       <span className={Styles.bolden}>
@@ -23,10 +25,12 @@ const InvalidMessage = () => (
       <ul>
         <li>The question is subjective in nature</li>
         <li>
-          The title, details, reporting start time, resolution source, and outcomes are in direct conflict.
+          The title, details, reporting start time, resolution source, and
+          outcomes are in direct conflict.
         </li>
         <li>
-          There are strong arguments for the market resolving as multiple outcomes.
+          There are strong arguments for the market resolving as multiple
+          outcomes.
         </li>
         <li>
           The resolution source does not provide a readily available answer.
@@ -35,10 +39,12 @@ const InvalidMessage = () => (
           The resolution source provides different answers to different viewers.
         </li>
         <li>
-          A resolution source is referenced in the description and is not specified in either the title or the resolution source field.
+          A resolution source is referenced in the description and is not
+          specified in either the title or the resolution source field.
         </li>
         <li>
-          The market refers to an asset that has a public ticker symbol, but is not referred to by that symbol.
+          The market refers to an asset that has a public ticker symbol, but is
+          not referred to by that symbol.
         </li>
       </ul>
     </div>


### PR DESCRIPTION
add according to to market header, so it'll show up on market trading page and reporting/disputing forms. fixed prettier issues.

![image](https://user-images.githubusercontent.com/3970376/68421679-543f1880-0164-11ea-999c-a506cbf16fea.png)
